### PR TITLE
feat(SvelteKit): add migration planning template

### DIFF
--- a/templates/sveltekit/meta.json
+++ b/templates/sveltekit/meta.json
@@ -11,6 +11,17 @@
         "API integration on client",
         "new feature module"
       ]
+    },
+    "migration": {
+      "description": "Plan and execute a migration in any SvelteKit codebase: replace an old externally-driven surface (a package, dependency version, tool, codegen pipeline, or framework API) with a new one across every coupled site, coordinated via a shared checklist, and retire the old surface. Stack-agnostic — the repo's tools, commands, and conventions are discovered, not assumed.",
+      "use_cases": [
+        "migrating from one package or library to another",
+        "upgrading a dependency across a breaking major version",
+        "migrating hand-written code into a codegen pipeline",
+        "adopting a new framework API or pattern tied to a version bump",
+        "repointing every consumer off a deprecated surface, then deleting it",
+        "any adopt-the-new-external-surface-and-remove-the-old-version job across many sites"
+      ]
     }
   }
 }

--- a/templates/sveltekit/migration/01-discover-and-scope.md
+++ b/templates/sveltekit/migration/01-discover-and-scope.md
@@ -1,0 +1,91 @@
+# Phase 1: Discover & Scope
+
+A migration template must not assume your stack. This phase reads the **target repo** to learn how it
+builds, tests, and organizes code, then pins down exactly which old surface is leaving and which new
+surface is arriving. Everything downstream references what you record here.
+
+## Objective
+
+- Discover the repo-specific **parameters** (commands, tools, conventions) the rest of the plan uses.
+- Identify the **old surface** (what is being migrated away from) and the **new surface** (what is
+  being adopted).
+- Declare the **behavior contract**: preserved, or changed with an explicit list of expected deltas.
+
+## Critical Rules
+
+1. **Record parameters, don't hardcode tools.** No later phase may name a command or path that was
+   not discovered here.
+2. **Name the old surface as a searchable token.** You must be able to `grep` for it later (import
+   specifier, symbol, package name, API call).
+3. **Decide the behavior contract now.** A migration either preserves behavior or changes it on
+   purpose — never leave this implicit.
+
+## Step 1: Discover Repo Parameters
+
+Inspect the target repo and record the results in `00-overview.md`:
+
+```bash
+# Package manager: lockfile tells you which
+ls pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null
+
+# Scripts: the real typecheck / lint / test commands
+cat package.json   # read the "scripts" block; note the exact names used
+
+# Codegen present? (only relevant to some migrations)
+grep -in "generate" package.json
+grep -rln "@generated\|DO NOT EDIT\|AUTO-GENERATED" src/ 2>/dev/null
+
+# Import conventions: aliases and barrels in use
+cat svelte.config.* vite.config.* tsconfig*.json 2>/dev/null   # path aliases (e.g. $lib)
+```
+
+Record the **Discovered Parameters** table in `00-overview.md`:
+
+| Parameter | Discovered value |
+|-----------|------------------|
+| package manager | (from lockfile) |
+| typecheck command | (from scripts) |
+| lint command | (from scripts) |
+| test command | (from scripts) |
+| codegen pipeline | present / absent (+ regenerate command) |
+| path aliases / barrels | (from config) |
+
+## Step 2: Identify Old & New Surface
+
+State both precisely:
+
+- **Old surface** — what leaves, as a token you can search for. Examples: a package name, an import
+  specifier, a symbol/API, a directory, a deprecated pattern.
+- **New surface** — what is adopted in its place, and where it lives (a package, a generated module,
+  a utils/constants location, a new API).
+
+```bash
+# Confirm the old surface is real and find its blast radius (rough count now, full inventory in Phase 2)
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js | wc -l
+```
+
+## Step 3: Declare the Behavior Contract
+
+Choose one and record it in `00-overview.md`:
+
+- **Preserved** — observable behavior must be identical. Note which existing tests are the baseline;
+  confirm they are green on the current commit *before* any change.
+- **Intentional deltas** — behavior changes on purpose (common for major dependency upgrades). List
+  each expected delta and how it will be verified. Anything not on the list must still be unchanged.
+
+```bash
+# Find the tests that currently cover the old surface (baseline)
+grep -rn "<old-surface-token>" --include=*.test.* --include=*.spec.* .
+```
+
+## Output
+
+`00-overview.md` contains: **Goal · Scope · Old surface · New surface · Discovered Parameters ·
+Behavior contract (preserved | deltas list) · Success criteria**. This is the ground truth every
+later phase and the checklist reference.
+
+## Done when
+
+Discovered parameters recorded; old and new surface named with a searchable token; behavior contract
+declared with a green baseline (or an explicit deltas list). *(Carry each of these into
+`checklist.md` per the README convention.)*

--- a/templates/sveltekit/migration/02-inventory-and-mapping.md
+++ b/templates/sveltekit/migration/02-inventory-and-mapping.md
@@ -1,0 +1,98 @@
+# Phase 2: Inventory & Mapping
+
+Turn the old surface into a complete list of **units** and decide, per unit, what happens to it. This
+is where the migration becomes concrete and idempotent: some units need full work, some only need a
+repoint, some are already done, some are dead and just get dropped.
+
+## Objective
+
+- Enumerate every **unit** coupled to the old surface (the smallest independently-repointable thing).
+- Define the **mapping** from each unit to its new form — in whichever shape fits.
+- Assign each unit a **terminal state** so no-ops and dead code are not re-worked.
+
+## Critical Rules
+
+1. **Inventory is exhaustive before execution.** A missed unit becomes a dangling reference at retire
+   time. Enumerate first, work second.
+2. **The unit is not the file.** A file may couple to the old surface in several independent places;
+   each is its own unit and its own checklist row.
+3. **Choose the mapping shape deliberately** (see Step 2) — do not force per-unit routing onto a
+   uniform codemod, or vice versa.
+
+## Step 1: Enumerate Units
+
+Using the old-surface token from Phase 1:
+
+```bash
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+```
+
+Classify what kind of unit each hit is — the classification only matters insofar as it drives the
+mapping. Common kinds and where they tend to go:
+
+| Unit kind | Typical new home (per repo — from discovery) |
+|-----------|----------------------------------------------|
+| a data type / shape | a codegen spec (if the repo has one) or a types module |
+| a transform / caster / helper fn | a utils module |
+| a default / literal value | a constants module |
+| a UI component | a components location |
+| a call-site of an old API | the equivalent new API call |
+| non-representable code (e.g. holds functions, conditional shapes) | a hand-written location — never codegen |
+
+## Step 2: Define the Mapping (pick the shape)
+
+Pick whichever matches this migration:
+
+**Per-unit routing** — each unit goes to a specific chosen destination. Good for consolidations and
+fan-outs (one source file's type/fn/constant each land in different homes).
+
+| Unit | Old location | New home |
+|------|--------------|----------|
+| `WidgetType` | old surface | types / codegen spec |
+| `castWidget` | old surface | utils |
+| `WIDGET_DEFAULTS` | old surface | constants |
+
+**Uniform transform rule** — one rule applied to every matching site. Good for package swaps,
+API-shape changes, pattern/version migrations.
+
+```text
+Rule: <old API call/pattern>  →  <new API call/pattern>
+e.g.  oldClient.get(url)       →  newClient.fetch(url)
+Applies to: every site found in Step 1.
+```
+
+Record which shape you chose in `00-overview.md`.
+
+## Step 3: Assign Terminal States (reconcile)
+
+For each unit run two checks and assign exactly one state:
+
+```bash
+# Check A — is it used anywhere live (outside dead code)?
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+
+# Check B — does the new surface already cover it?
+grep -rn "\b<Unit>\b" <new-surface-location>
+```
+
+| Terminal state | When | Action |
+|----------------|------|--------|
+| `NO-OP` | New surface already covers it AND nothing references the old one | nothing to do |
+| `REPOINT-ONLY` | New surface already covers it, but consumers still use the old | only repoint (Phase 4) |
+| `MIGRATE` | New surface does not cover it yet; unit is live | adopt new + repoint |
+| `DROP` | Nothing live uses it (Check A empty) | do not migrate; remove at retire |
+
+## Output
+
+A complete unit ledger: every unit with its kind, its mapping (destination or rule), and exactly one
+terminal state.
+
+**Materialize `checklist.md` now** — create the file in the plan directory and emit one row per unit,
+using the row schema and terminal states from the README. This file is the shared coordination spine
+for every later phase; phases 03–05 update its rows rather than re-authoring it.
+
+## Done when
+
+Every old-surface site is enumerated as a unit; the mapping shape is chosen and filled; every unit
+has exactly one terminal state; dead units are `DROP` and already-done units are `NO-OP`. *(Emit these
+as checklist rows per the README convention.)*

--- a/templates/sveltekit/migration/03-sequencing.md
+++ b/templates/sveltekit/migration/03-sequencing.md
@@ -1,0 +1,69 @@
+# Phase 3: Sequencing
+
+Some units depend on others: a type references another type, a helper uses a constant. Migrate a
+dependent before its dependency and you import from the soon-to-be-retired old surface. This phase
+produces a safe order and groups cycles that must move together.
+
+> **SKIP this phase** when units are independent (typical of uniform package/API-swap migrations
+> where each call-site stands alone). Mark it `SKIPPED` with that reason and move on.
+
+## Objective
+
+- Build the **dependency graph** over the units (including edges that cross owners).
+- Produce a **leaf-first** order.
+- Detect **cycles** and collapse each into one **combined unit** that migrates together.
+
+## Critical Rules
+
+1. **Leaf-first.** A unit is workable only once every unit it depends on is `done` (or `NO-OP`).
+2. **Cycles migrate together.** Mutually-referencing units cannot be split across PRs — each would
+   import the not-yet-migrated other. Co-migrate them as one combined unit.
+3. **Ignore dead nodes.** Remove `DROP`/`NO-OP` units before ordering.
+
+## Step 1: Extract Dependencies
+
+For each `MIGRATE`/`REPOINT-ONLY` unit, find which other in-scope units it references:
+
+```bash
+grep -n "\b\(<other-in-scope-units>\)\b" <file-defining-Unit>
+```
+
+| Unit | Depends on (in-scope units) |
+|------|-----------------------------|
+| `A` | `B`, `C` |
+| `B` | `A` |
+| `C` | — (leaf) |
+
+## Step 2: Collapse Cycles
+
+Any mutually-reachable set is a cycle → one combined unit, one PR:
+
+| Combined unit | Members | Reason |
+|---------------|---------|--------|
+| `A+B` | `A`, `B` | mutual reference |
+
+## Step 3: Leaf-First Waves
+
+Order so every unit follows its dependencies. Units in the same wave are independent and can be
+worked in parallel by different owners:
+
+```text
+Wave 1 (leaves):  C, ...
+Wave 2:           A+B (combined), ...
+Wave 3:           units depending on A/B
+```
+
+## Step 4: Label Cross-Owner Edges
+
+If an edge crosses owners (owner X's unit depends on owner Y's unit), record it — it becomes the
+`depends-on` value in the checklist and gates when that row may start.
+
+## Output
+
+A wave-ordered list of units and combined units, with cross-owner edges labeled. Feeds the
+`depends-on` column of `checklist.md`.
+
+## Done when
+
+Dead nodes removed; every remaining unit's in-scope dependencies recorded; all cycles collapsed into
+named combined units; a valid leaf-first ordering exists. *(Populate `depends-on` in the checklist.)*

--- a/templates/sveltekit/migration/04-execute-and-repoint.md
+++ b/templates/sveltekit/migration/04-execute-and-repoint.md
@@ -1,0 +1,81 @@
+# Phase 4: Execute & Repoint
+
+The repeatable ritual for taking **one unit** from `todo` to `done`. Run it per checklist row, in the
+Phase 3 wave order, using only the conventions discovered in Phase 1. It is the same loop whether one
+person runs it many times or many people each run it once.
+
+## Objective
+
+- Adopt the **new surface** for the unit (per its terminal state and mapping).
+- Repoint **every** consumer off the old surface.
+- Keep the work **parallel-safe** so concurrent owners do not serialize on shared files.
+
+## Critical Rules
+
+1. **Never edit the old surface in place.** Adopt the new surface at each site; the old surface stays
+   untouched until retire (Phase 5).
+2. **A unit is not `done` while any consumer still uses the old surface for it.** Repoint everything.
+3. **Split shared imports; do not rewrite them wholesale.** Editing a shared barrel for every unit
+   serializes the team — change only the one line your unit needs.
+
+## The Ritual (per unit)
+
+### Step 0: Confirm state & dependencies
+
+Confirm the row's terminal state and that all `depends-on` rows are `done`.
+`NO-OP` → check off with a note, stop. `DROP` → nothing now (retire removes it), stop.
+
+### Step 1: Adopt the new surface
+
+- `MIGRATE`: create the unit at its new home (write the codegen spec entry / add to utils / constants
+  / types, or call the new API), per the mapping from Phase 2. If the new home is a partially-covering
+  codegen artifact, add only what is missing (Phase 2 Check B).
+- `REPOINT-ONLY`: the new surface already covers it — skip authoring, go to Step 3.
+
+### Step 2: Regenerate if codegen
+
+If the new home is a generated artifact, regenerate now using the discovered command and follow the
+codegen hygiene rules (see QUICK-REFERENCE): rebase → regenerate → resolve, one unit per PR, never
+hand-edit generated output.
+
+### Step 3: Find every consumer
+
+```bash
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+```
+
+### Step 4: Repoint consumers + split shared imports
+
+Point each consumer at the new surface. Split shared/barrel imports so unrelated units don't collide:
+
+```typescript
+// BEFORE — one shared import; every unit's repoint touches this line
+import { WidgetType, Money, castWidget } from '<old-surface>';
+
+// AFTER — split; only the migrated unit moves, one line changes per unit
+import { WidgetType } from '<new-home>';        // migrated this row
+import { Money, castWidget } from '<old-surface>';  // still old, other rows
+```
+
+This lets two owners repoint two units in the same consumer file with minimal conflict, and keeps each
+row's diff reviewable in isolation.
+
+### Step 5: Record any surface-specific flags
+
+If the new surface needs per-unit options (e.g. a generator's nullability/optional handling, or an
+API's changed defaults), record them on the checklist row so a reviewer sees the choice was deliberate.
+
+### Step 6: Verify the unit
+
+Run the per-unit verification (Phase 5, Part A) before marking the row `in-review`/`done`.
+
+## Output
+
+Per unit: the new-surface artifact adopted, every consumer repointed, shared imports split, and the
+checklist row advanced. The old surface is untouched.
+
+## Done when
+
+For each unit: terminal state honored; new surface adopted (or confirmed already covering); every
+consumer repointed off the old surface; shared imports split, not wholesale-rewritten; old surface
+unchanged. *(Advance the row's `status` in the checklist.)*

--- a/templates/sveltekit/migration/05-verify-and-retire.md
+++ b/templates/sveltekit/migration/05-verify-and-retire.md
@@ -1,0 +1,86 @@
+# Phase 5: Verify & Retire
+
+Two gates and a cutover. The **per-unit gate** runs before each row is `done`. The **global gate**
+runs once, after every row is done, and is the only thing that unlocks **retire** — the atomic removal
+of the old surface. Retire before the global gate passes and you leave dangling references; retire is
+the last thing that happens, and it happens all at once.
+
+## Objective
+
+- Verify each unit against the **declared behavior contract** using the **discovered** commands.
+- Pass the **global gate**: zero references to the old surface remain where they should not.
+- **Retire** the old surface atomically.
+
+## Critical Rules
+
+1. **Verify against the contract from Phase 1.** Preserved → the baseline tests still pass unchanged.
+   Intentional deltas → each listed delta is confirmed and nothing off-list changed.
+2. **The global gate is a hard precondition for retire.** No "clean up later."
+3. **Retire is atomic and wholesale.** Remove the entire old surface in one PR — never trickle-remove,
+   which reintroduces half-migrated state.
+
+## Part A: Per-Unit Gate (per row, from Phase 4 Step 6)
+
+Run the repo's discovered commands:
+
+```bash
+<typecheck>   # must be clean
+<lint>        # no dangling imports off the old surface
+<test>        # behavior contract holds (baseline green, or expected deltas match)
+```
+
+Plus the per-unit no-lingering check:
+
+```bash
+# No consumer still reaches this unit through the old surface
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+# Expect: only the new-surface definition; nothing via the old surface
+```
+
+Per-unit checklist: typecheck clean · tests match the contract · no consumer uses the old surface for
+this unit · new surface is the single source of truth · row marked `done`.
+
+## Part B: Global Gate (once, after all rows done)
+
+Every non-`DROP`/`NO-OP` row is `done`. Now prove the old surface is fully orphaned:
+
+```bash
+# Zero references to the old surface where it should no longer appear
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+# Expect: nothing (or only the old surface's own files, about to be removed).
+
+# Also check barrels, path aliases, and dependency manifests
+grep -rn "<old-surface-token>" src/**/index.* svelte.config.* vite.config.* tsconfig*.json package.json 2>/dev/null
+```
+
+Global gate checklist: all rows `done` · repo-wide grep clean · no barrel re-exports the old surface ·
+aliases/manifest no longer reference it · full `<typecheck> && <lint> && <test>` green on the
+integrated branch.
+
+## Part C: Retire (only when Part B passes)
+
+In a single PR:
+
+```bash
+# Remove the old surface wholesale — delete files, and drop the dependency if it was a package
+git rm -r <old-surface-path>
+# If the old surface was a package, remove it from the manifest and update the lockfile
+<package-manager> remove <old-package>
+```
+
+- Remove now-dead path aliases pointing at the old surface.
+- Re-run the full discovered suite on the retire PR; it must be green with the old surface gone.
+
+Retire checklist: old surface removed in one PR · dead aliases/manifest entries cleaned · full suite
+green **after** removal · retire row in `checklist.md` marked `done`.
+
+## Output
+
+Every unit verified and `done`, the global gate passed, and the old surface atomically retired. The
+migration is complete and satisfies its declared behavior contract.
+
+## Done when
+
+Per-unit gate passed for every row; global gate clean; old surface removed atomically in one PR; full
+discovered suite green with it gone; the Phase 1 behavior contract holds end-to-end. *(Check the gate
+and retire rows in the checklist.)*

--- a/templates/sveltekit/migration/QUICK-REFERENCE.md
+++ b/templates/sveltekit/migration/QUICK-REFERENCE.md
@@ -1,0 +1,71 @@
+# Migration — Quick Reference
+
+## Is it a migration?
+
+> **Migration = external driver** (package, dep version, tool, codegen, framework API) → adopt the new
+> surface everywhere and **retire the old**. Behavior preserved *or* intentionally changed.
+> **Refactor = internal driver**, behavior invariant, nothing retired → use the `refactor` template.
+
+package swap · dep major upgrade · hand-written→codegen · framework-API/version pattern change → all
+migration, differing only in what old→new surface discovery finds.
+
+## Core invariant
+
+**Old surface fully replaced and retired.** Done = every site on the new surface + zero references to
+the old. (Behavior contract is a separate Phase-1 choice: preserved, or an explicit deltas list.)
+
+## Discover, never assume
+
+Phase 1 reads the repo for: package manager · typecheck/lint/test commands · codegen presence ·
+path aliases/barrels. Every later phase uses these params — no hardcoded tools.
+
+## Phases
+
+| Phase | Does |
+|-------|------|
+| 1 Discover & Scope | detect params · name old/new surface · declare behavior contract → `00-overview.md` |
+| 2 Inventory & Mapping | enumerate units · pick mapping shape · assign terminal states |
+| 3 Sequencing | dependency order, cycles → combined units (SKIP if independent) |
+| 4 Execute & Repoint | adopt new surface · repoint consumers · split shared imports |
+| 5 Verify & Retire | per-unit gate · global gate · atomic retire |
+
+## Mapping shapes (pick one)
+
+- **Per-unit routing** — each unit → a chosen home (type→spec/types, fn→utils, const→constants).
+- **Uniform transform rule** — `old API/pattern → new API/pattern` applied to N sites.
+
+## Terminal states
+
+`MIGRATE` (adopt new + repoint) · `REPOINT-ONLY` (new exists, only repoint) · `DROP` (dead — remove) ·
+`NO-OP` (already on new surface).
+
+## Checklist = the spine (multi-person coordination)
+
+One unit = one row = one line. `| # | unit | old→new | terminal | owner | depends-on | status | PR |`
+Status: `todo → claimed → in-progress → in-review → done`. Gate rows unlock only when all units `done`.
+**Merge discipline:** claim only your row · never reflow/re-sort · append your PR link.
+
+## Codegen hygiene (only if new home is a committed generated artifact)
+
+Never hand-edit generated output · rebase → regenerate → resolve before each push · one unit per PR ·
+record per-unit generator flags (nullability, optional handling) on the checklist row.
+
+## Repoint safely (Phase 4)
+
+```typescript
+// split shared imports so parallel rows don't collide — one line per unit
+import { WidgetType } from '<new-home>';           // migrated
+import { Money } from '<old-surface>';             // still old, other rows
+```
+
+## Global gate before retire
+
+```bash
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+# expect nothing → then: git rm -r <old-surface-path> ; <pm> remove <old-package>
+```
+
+## Verify
+
+Run the **discovered** `<typecheck> · <lint> · <test>` against the declared behavior contract, plus
+the global-gate grep.

--- a/templates/sveltekit/migration/README.md
+++ b/templates/sveltekit/migration/README.md
@@ -1,0 +1,104 @@
+# Migration Template
+
+Plan and execute a **migration** in any SvelteKit codebase: replace an old, externally-driven
+surface with a new one across every site that touches it, coordinate the work across one or more
+people via a shared checklist, and retire the old surface once nothing references it.
+
+This template is **stack-agnostic**. It never assumes a package manager, codegen tool, test runner,
+or directory layout — every such detail is **discovered from the target repo** in Phase 1 and
+referenced as a parameter thereafter.
+
+## What counts as a migration (vs a refactor)
+
+> **Migration = the driver is external.** A new package, dependency version, tool, codegen pipeline,
+> or framework API. There is an old externally-coupled surface to leave and a new one to adopt, and
+> you **end by retiring the old coupling**. Behavior may be preserved or may shift intentionally.
+>
+> **Refactor = the driver is internal** (readability, structure, dedup). No external surface changes,
+> behavior is invariant, nothing external is retired. Use the `refactor` template for that.
+
+Examples that belong here: package swap, dependency major upgrade, hand-written → codegen, adopting a
+framework API tied to a version bump. These differ only in *what old→new surface* Phase 1 discovers —
+they are **not** separate templates.
+
+## Core Invariant
+
+**The old surface is fully replaced and retired.** The migration is done only when every coupled
+site uses the new surface and zero references to the old surface remain. This — not
+behavior-preservation — is the contract at the center. (Behavior preservation is a *per-migration
+choice*, declared in Phase 1: preserved, or changed with an explicit list of expected deltas.)
+
+## Principles
+
+1. **Discover, never assume.** Commands, tools, destinations, and conventions come from the target
+   repo (Phase 1), not from this template.
+2. **The unit is the smallest independently-repointable thing** — a symbol, a call-site, an import —
+   not a whole file. One file often couples to the old surface in several independent places.
+3. **The mapping is general.** "Where does each unit go" can be *per-unit routing* (unit → a chosen
+   destination) or a *uniform transform rule* (old API → new API applied to N sites). Pick the shape
+   that fits; the template does not force one.
+4. **Never edit the old surface in place.** Adopt the new surface at each site; remove the old surface
+   wholesale in the final phase.
+5. **The checklist is the spine.** For any migration touched by more than one person, `checklist.md`
+   is the single shared, committed coordination artifact. Everything else is read-only methodology.
+6. **Global gate before retire.** The old surface is deleted only after a repo-wide check shows no
+   remaining references.
+
+## Phases
+
+1. **Discover & Scope** — detect repo parameters (typecheck/lint/test commands, package manager,
+   import conventions, codegen presence); identify the **old** and **new** surface; declare the
+   behavior contract (preserved, or the list of intended deltas). Fills `00-overview.md`.
+2. **Inventory & Mapping** — enumerate every site coupled to the old surface; define the mapping
+   (per-unit routing or uniform rule); assign each unit a reconcile terminal state.
+3. **Sequencing** — order units by dependency, leaf-first, grouping cycles; *SKIP* when units are
+   independent.
+4. **Execute & Repoint** — the per-unit ritual: adopt the new surface, repoint consumers, keep the
+   work parallel-safe — all using the discovered conventions.
+5. **Verify & Retire** — verify with the discovered commands against the declared behavior contract,
+   pass the global gate, and retire the old surface atomically.
+
+## The Shared Checklist Convention
+
+`checklist.md` (generated into the plan) is where a team coordinates. It is authored once here and
+reused by the `refactor` template. It rides *with the artifact* so co-editors see the rules where
+they work.
+
+**Row schema — one unit per row, one row per line:**
+
+```markdown
+| # | unit | old→new | terminal | owner | depends-on | status | PR |
+|---|------|---------|----------|-------|-----------|--------|----|
+| 1 | castWidget | old caster → utils | MIGRATE | @a | — | todo | — |
+| 2 | WIDGET_DEFAULTS | old default → constants | MIGRATE | @b | — | todo | — |
+```
+
+**Terminal states:** `MIGRATE` (adopt new + repoint) · `REPOINT-ONLY` (new already exists, only
+repoint consumers) · `DROP` (nothing live uses it — remove, don't migrate) · `NO-OP` (already fully
+on the new surface).
+
+**Status lifecycle:** `todo → claimed → in-progress → in-review → done`.
+
+**Gate rows** (unlock only when all unit rows are `done`): source-immutability holds · global gate
+passes · retire.
+
+**Merge discipline (why concurrent editing stays conflict-free):** one unit = one row = one line;
+claim by editing only your row; never reflow or re-sort the table; append your PR link. Independent
+lines mean two owners rarely touch the same line.
+
+> Note: the MCP loader serves only each template's own README/phases/QUICK-REFERENCE — there is no
+> cross-template include. "Shared with `refactor`" means the same authored convention text, kept
+> consistent by hand.
+
+## When to Use
+
+- Swapping a package/library for another across the codebase
+- A breaking dependency upgrade that touches many call-sites
+- Moving hand-written code into a codegen pipeline
+- Adopting a framework API/pattern tied to a version bump
+- Any job that ends with "…and delete the old version"
+
+## When NOT to Use
+
+- Internal reshaping with no external surface change and invariant behavior → use `refactor`
+- Building something new with no existing surface → use `client-module`

--- a/templates/sveltekit/migration/meta.json
+++ b/templates/sveltekit/migration/meta.json
@@ -1,0 +1,26 @@
+{
+  "name": "migration",
+  "description": "Plan and execute a migration in any SvelteKit codebase: replace an old externally-driven surface (a package, dependency version, tool, codegen pipeline, or framework API) with a new one across every coupled site, coordinated via a shared checklist, and retire the old surface. Stack-agnostic — the repo's tools, commands, and conventions are discovered, not assumed.",
+  "use_cases": [
+    "migrating from one package/library to another (e.g. one HTTP client, date lib, or UI kit to another)",
+    "upgrading a dependency across a breaking major version",
+    "migrating hand-written code into a codegen pipeline",
+    "adopting a new framework API or pattern tied to a version bump (e.g. a runes-style rewrite)",
+    "moving a coupled surface to a new tool or convention and retiring the old one",
+    "repointing every consumer off a deprecated surface, then deleting it",
+    "any 'adopt the new external surface and remove the old version' job across many sites"
+  ],
+  "phases": [
+    { "file": "01-discover-and-scope.md", "name": "Discover & Scope" },
+    { "file": "02-inventory-and-mapping.md", "name": "Inventory & Mapping" },
+    { "file": "03-sequencing.md", "name": "Sequencing" },
+    { "file": "04-execute-and-repoint.md", "name": "Execute & Repoint" },
+    { "file": "05-verify-and-retire.md", "name": "Verify & Retire" }
+  ],
+  "verification": [
+    { "command": "<typecheck>", "description": "The repo's typecheck command, detected in Phase 1 (e.g. a svelte-check script) — must be clean" },
+    { "command": "<lint>", "description": "The repo's lint command, detected in Phase 1 — catches dangling imports off the old surface" },
+    { "command": "<test>", "description": "The repo's test command, detected in Phase 1 — proves the migration's behavior contract (preserved, or matching the expected deltas)" },
+    { "command": "grep -rn \"<old-surface-token>\" src/ --include=*.ts --include=*.svelte --include=*.js", "description": "Global gate before retire: zero references to the old surface remain anywhere it should not" }
+  ]
+}


### PR DESCRIPTION
**What**

Adds a migration template under templates/sveltekit: a five-phase plan for replacing an old externally-driven surface — a package, dependency version, tool, codegen pipeline, or framework API — with a new one across every coupled call-site, then retiring the old surface once nothing references it.

**Why**

The existing templates cover building new modules and internal refactors, but not the common "adopt the new external surface and delete the old version" job that touches many sites and multiple people. This template fills that gap with an explicit sequencing and retirement discipline.

**Approach**

Stack-agnostic by design — the repo's typecheck/lint/test commands, path aliases, and codegen conventions are discovered in Phase 1, not assumed — so it applies to any SvelteKit codebase.

| **Phase** | **Purpose** |
| --- | --- |
| 01 Discover & Scope | Detect commands, aliases, and the old/new surfaces |
| 02 Inventory & Mapping | Enumerate every site as a unit with one terminal state; materialize `checklist.md` |
| 03 Sequencing | Derive a leaf-first, dependency-safe order |
| 04 Execute & Repoint | Per-unit ritual: adopt new, repoint consumers, keep work parallel-safe |
| 05 Verify & Retire | Verify against the behavior contract, pass the global gate, retire atomically |

checklist.md is the coordination spine: one unit per row, claimed and advanced independently so multiple owners edit conflict-free. The convention is shared (by hand) with the refactor template.

**Contents**

README, QUICK-REFERENCE, five phase docs, and meta.json (phases + verification steps), plus a templates/sveltekit/meta.json registry entry — 9 files, +637 lines, docs only.
