### PR TITLE
feat(sveltekit): add upgrade-readiness template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,74 +4,124 @@ Thank you for your interest in contributing to Skulls!
 
 ## Adding New Templates
 
-Templates are the core of Skulls. Here's how to add new ones:
+Templates are the core of Skulls. Here's how to add new ones.
 
-### 1. Create Language Directory (if new language)
+The canonical schema is defined by the TypeScript types in
+[`mcp/src/types.ts`](mcp/src/types.ts) (`RootMeta`, `LanguageMeta`, `TemplateMeta`). If
+this document and the types disagree, the types are the source of truth.
 
-If adding templates for a new language/framework, create a directory under `templates/`:
+### 1. Register the Language in Root Metadata (if new language)
 
-```text
-templates/
-├── rust/           # existing
-├── your-language/  # new
-│   └── meta.json
-```
-
-### 2. Add Language Metadata
-
-Create a `meta.json` in your language directory:
+If adding templates for a new language, add an entry to `templates/meta.json`:
 
 ```json
 {
-  "name": "Your Language",
-  "description": "Brief description of what this language/framework covers",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "languages": {
+    "your-language": {
+      "description": "Brief description of what this language/framework covers"
+    }
+  }
 }
 ```
 
-### 3. Create Template Directory
-
-Add a template directory with its own `meta.json` and phase files:
+### 2. Create the Language Directory
 
 ```text
-templates/your-language/
-└── your-template/
-    ├── meta.json
-    ├── 01-first-phase.md
-    ├── 02-second-phase.md
-    └── ...
+templates/
+├── rust/              # existing
+├── sveltekit/         # existing
+├── your-language/     # new
+│   ├── meta.json      # language-level metadata (see step 3)
+│   └── your-template/ # one directory per template (see step 4)
 ```
 
-### 4. Template Metadata
+### 3. Add Language-Level `meta.json`
 
-Each template needs a `meta.json`:
+Create `templates/your-language/meta.json` listing every template the language provides:
 
 ```json
 {
-  "name": "Your Template",
+  "language": "your-language",
+  "templates": {
+    "your-template": {
+      "description": "What this template helps plan",
+      "use_cases": [
+        "primary use case",
+        "another use case",
+        "another use case"
+      ]
+    }
+  }
+}
+```
+
+Fields:
+
+- `language` — kebab-case identifier, matches the directory name
+- `templates` — map of `<template-name>` to its description and use cases
+- `use_cases` — short phrases the MCP server surfaces for template discovery
+
+### 4. Create the Template Directory
+
+Each template lives in its own directory with a `meta.json`, a `README.md`, numbered phase
+files, and an optional `QUICK-REFERENCE.md`:
+
+```text
+templates/your-language/your-template/
+├── meta.json
+├── README.md              # template overview (read as the `overview` field)
+├── 01-first-phase.md
+├── 02-second-phase.md
+├── ...
+└── QUICK-REFERENCE.md     # optional condensed reference
+```
+
+### 5. Template-Level `meta.json`
+
+```json
+{
+  "name": "your-template",
   "description": "What this template helps plan",
-  "version": "1.0.0",
-  "phases": [
-    { "number": 1, "name": "First Phase", "file": "01-first-phase.md" },
-    { "number": 2, "name": "Second Phase", "file": "02-second-phase.md" }
+  "use_cases": [
+    "primary use case",
+    "another use case"
   ],
-  "quickReference": "Optional quick reference content",
+  "phases": [
+    { "file": "01-first-phase.md", "name": "First Phase" },
+    { "file": "02-second-phase.md", "name": "Second Phase" }
+  ],
   "verification": [
-    "Command or check to verify implementation"
+    { "command": "your-lint-command", "description": "What this check verifies" },
+    { "command": "your-test-command", "description": "What this check verifies" }
   ]
 }
 ```
 
-### 5. Phase Files
+Notes:
+
+- `name` must match the template directory name (kebab-case).
+- Phase `number` is **parsed from the filename prefix** (`01-`, `02-`, ...), not stored in
+  `meta.json`. Use two-digit, hyphen-separated prefixes.
+- `verification` is an array of `{ command, description }` objects, not strings.
+- `QUICK-REFERENCE.md` is a separate file loaded by `get_quick_reference`. Do **not** add a
+  `quickReference` field to `meta.json`.
+- There is no `version` field on the template meta.
+
+### 6. Phase Files
 
 Each phase file should include:
 
-- Clear objective
-- Step-by-step guidance
-- Code patterns/examples where helpful
-- Validation criteria
+- **Objective** — what this phase accomplishes
+- **Step-by-step guidance** — numbered sections with concrete instructions
+- **Code / command examples** — where helpful
+- **Validation criteria** — a trackable `[ ]` checklist for phase completion
 
-The MCP server reads templates dynamically - no code changes required!
+See `templates/GLOBAL-INSTRUCTIONS.md` for the mandatory plan-output rules that every
+template implicitly inherits.
+
+The MCP server reads templates dynamically from the filesystem — no code changes required
+when adding or updating templates.
 
 ## Submitting Changes
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -8,7 +8,7 @@ Project templates and standards organized by language/technology.
 |----------|-------------|--------|
 | [rust](./rust/) | Backend API templates (Axum, SQLx) | Active |
 | [svelte](./svelte/) | Svelte 5 component templates | Planned |
-| [sveltekit](./sveltekit/) | SvelteKit application templates | Planned |
+| [sveltekit](./sveltekit/) | SvelteKit application templates | Active |
 | [typescript](./typescript/) | TypeScript type patterns | Planned |
 | [javascript](./javascript/) | JavaScript utility patterns | Planned |
 | [css](./css/) | CSS styling conventions | Planned |

--- a/templates/sveltekit/meta.json
+++ b/templates/sveltekit/meta.json
@@ -11,6 +11,18 @@
         "API integration on client",
         "new feature module"
       ]
+    },
+    "upgrade-readiness": {
+      "description": "Readiness audit and go/no-go for major SvelteKit changes: deps, configs, breaking impact, CI/CD, validation. Precedes a migration/refactor execution plan.",
+      "use_cases": [
+        "SvelteKit 1 to 2 upgrade",
+        "Svelte 4 to 5 upgrade in a SvelteKit app",
+        "major Vite / TypeScript / Node bump",
+        "adapter or deployment target change",
+        "breaking-change impact quantification",
+        "CI/CD readiness before a disruptive change",
+        "go / no-go on a large refactor or upgrade"
+      ]
     }
   }
 }

--- a/templates/sveltekit/upgrade-readiness/01-dependency-audit.md
+++ b/templates/sveltekit/upgrade-readiness/01-dependency-audit.md
@@ -1,0 +1,112 @@
+# Phase 1: Dependency Audit
+
+Map every direct and dev dependency to a version compatible with the target state of the change.
+Surface peer conflicts, engine bumps, and removed/deprecated packages.
+
+## Inputs
+
+- The target release's official migration / upgrade guide
+- Current `package.json` and lockfile
+- Current `.nvmrc` / `.node-version` / `packageManager` field
+
+## Process
+
+### 1. Capture current state
+
+First, **detect the package manager** — the lockfile and `packageManager` field decide it. Every
+command in this template that would run a package manager is written as `<pm>`; substitute the
+detected tool (`pnpm` / `npm` / `yarn`) throughout the plan.
+
+```bash
+# Detect <pm>: pnpm-lock.yaml -> pnpm, package-lock.json -> npm, yarn.lock -> yarn
+ls pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null
+grep '"packageManager"' package.json
+
+<pm> list --depth 0
+node -v
+cat .nvmrc 2>/dev/null || cat .node-version 2>/dev/null
+grep '"engines"\|"packageManager"' package.json
+```
+
+### 2. Read the target release's migration guide
+
+Extract from it:
+
+- Minimum Node.js version
+- Minimum versions of `@sveltejs/kit`, `svelte`, `vite`, `typescript`
+- Any dep that moved from transitive to **peer** (must be listed explicitly)
+- Any dep that was **removed** (to be deleted)
+- Any dep that was **replaced** (old → new name or import)
+- Adapter compatibility matrix for your project's adapter
+
+### 3. Sweep the Svelte / SvelteKit ecosystem
+
+```bash
+grep -E '"(@?svelte|svelte-|@sveltejs/)' package.json
+```
+
+For each package, check:
+
+- Compatible release for the target `@sveltejs/kit` + `svelte` versions
+- Peer dependency range
+- Deprecation status (replaced by a built-in? moved to a runes-aware variant?)
+
+### 4. Sweep SvelteKit-facing libraries
+
+```bash
+grep -E '"(superforms|sveltekit-|skeleton-|shadcn-svelte|formsnap|bits-ui|melt-ui)' package.json
+```
+
+For each: SK-target support, required version, breaking changes in its own changelog.
+
+### 5. Check the adapter
+
+The project's adapter is a first-class concern:
+
+```bash
+grep -E '"@sveltejs/adapter-' package.json
+```
+
+Pin the adapter major that the target `@sveltejs/kit` supports.
+The adapter's own changelog is the source of truth — NOT the SvelteKit migration guide.
+
+### 6. Engine requirements
+
+Update across all environments where they appear:
+
+- `package.json#engines`
+- `.nvmrc` / `.node-version`
+- `packageManager` field
+- CI / Docker base images (audited fully in Phase 4)
+
+### 7. Peer conflict dry-run
+
+```bash
+<pm> install --dry-run
+```
+
+For each conflict: `{package} requires {x}, conflicts with {y}, resolution: {z}`.
+
+## Output
+
+Dependency mapping table:
+
+| Package | Current | Target | Action | Reason |
+|---------|---------|--------|--------|--------|
+| ... | ... | ... | upgrade / add / remove / replace | peer / removed / engine / ... |
+
+Plus: peer conflict list, adapter version decision, engine bumps.
+
+## Verification
+
+- [ ] Target release's migration guide read in full
+- [ ] `@sveltejs/kit` target version recorded
+- [ ] Adapter major decided and verified against the adapter's own changelog
+- [ ] Any peer-dep-promotions (transitive → peer) listed as direct deps
+- [ ] `svelte` target version recorded (if bumping compiler)
+- [ ] All direct deps mapped
+- [ ] All dev deps mapped
+- [ ] Removed packages documented
+- [ ] Peer conflicts listed with resolutions
+- [ ] Node.js minimum confirmed across environments
+- [ ] `<pm> install --dry-run` passes (or conflicts documented)

--- a/templates/sveltekit/upgrade-readiness/02-config-changes.md
+++ b/templates/sveltekit/upgrade-readiness/02-config-changes.md
@@ -1,0 +1,137 @@
+# Phase 2: Config Changes
+
+Catalogue every config file touched by the change. Record exact before/after for each.
+
+## Inputs
+
+- The target release's migration guide (config section)
+- Phase 1 dependency decisions (import paths and package names may have moved)
+
+## Process
+
+### 1. Inventory configs
+
+```bash
+ls -la svelte.config.* vite.config.* tsconfig* .eslintrc* eslint.config.* 2>/dev/null
+ls -la src/hooks.server.* src/hooks.client.* 2>/dev/null
+ls -la .prettierrc* prettier.config.* postcss.config.* tailwind.config.* 2>/dev/null
+ls -la app.html app.d.ts 2>/dev/null
+```
+
+Record each file's role and whether the target release touches it.
+
+### 2. `svelte.config.js`
+
+Audit for:
+
+- Import paths that moved in the target release (e.g. preprocessor helpers may live in a different package)
+- Deprecated / removed compiler options
+- New compiler options to consider (e.g. strict / runes modes)
+- `kit.adapter` — re-validate with adapter major from Phase 1
+- `kit.alias` — verify `$lib`, `$app`, custom aliases still resolve
+- `kit.paths.base` / `kit.paths.assets` — re-test if set
+
+### 3. `vite.config.ts`
+
+```bash
+grep -n "sveltekit\|svelte\|preprocess" vite.config.* 2>/dev/null
+```
+
+Check:
+
+- `@sveltejs/kit/vite` still exports `sveltekit()` — unchanged across SK majors so far
+- Vite version in `package.json` matches target minimum
+- Custom plugins still compatible
+- `server.fs.allow` / `resolve.alias` still resolve
+
+### 4. `tsconfig.json`
+
+The SvelteKit-generated base is at `.svelte-kit/tsconfig.json` — extend, do not edit directly.
+
+```bash
+grep -n "moduleResolution\|verbatimModuleSyntax\|importsNotUsedAsValues\|extends" tsconfig.json
+```
+
+Check for:
+
+- Options deprecated in the target TypeScript version
+- Options replaced in the target TypeScript version
+- `moduleResolution` value compatible with target bundler
+- Types referenced by the target release (e.g. new ambient types)
+
+### 5. `src/hooks.server.ts` / `src/hooks.client.ts`
+
+Hooks files are commonly touched by framework-level breaking changes (control-flow helpers,
+cookie APIs, error handlers). Record whether the file exists and whether Phase 3 patterns touch it.
+
+```bash
+grep -n "handle\|handleFetch\|handleError" src/hooks.server.* 2>/dev/null
+```
+
+### 6. `app.html` / `app.d.ts`
+
+```bash
+grep -n "%sveltekit\." app.html 2>/dev/null
+cat src/app.d.ts 2>/dev/null
+```
+
+SvelteKit's `App` namespace interface (`App.Locals`, `App.PageData`, `App.Error`, `App.Platform`, `App.PageState`)
+may have new or changed shapes in the target release.
+
+### 7. ESLint / Prettier
+
+```bash
+grep -n "svelte\|eslint-plugin-svelte" eslint.config.* .eslintrc* 2>/dev/null
+grep "prettier-plugin-svelte" package.json
+```
+
+Check plugin versions against target Svelte compiler — new syntax (runes, snippets) requires
+plugins that understand it.
+
+### 8. CSS tooling (PostCSS / Tailwind)
+
+Usually unaffected. Re-test only if the preprocessor pipeline changes touch CSS processing.
+
+### 9. Environment variable configs
+
+```bash
+grep -rn "\$env/static\|\$env/dynamic" src/
+ls .env .env.local .env.production 2>/dev/null
+```
+
+Record which env vars are static (build-time) vs dynamic (runtime) — dynamic vars' resolution
+depends on adapter and may need re-testing after an adapter bump.
+
+### 10. Deployment config files
+
+```bash
+ls vercel.json netlify.toml wrangler.toml Dockerfile 2>/dev/null
+```
+
+Inventory here; diff planning happens in Phase 4.
+
+## Output
+
+Per-file changelog:
+
+| File | Current | New | Reason |
+|------|---------|-----|--------|
+| ... | ... | ... | ... |
+
+Include order-of-operations where changes are co-dependent
+(e.g., remove an old preprocessor package only *after* the new import path works).
+
+## Verification
+
+- [ ] All config files inventoried
+- [ ] Target release's migration guide config section applied to every relevant file
+- [ ] `svelte.config.js` diff specified
+- [ ] `vite.config.*` diff specified
+- [ ] `tsconfig.json` diff specified (deprecated options removed, new ones added)
+- [ ] `src/hooks.*` diff specified (if touched by Phase 3 patterns)
+- [ ] `src/app.d.ts` `App` namespace reviewed
+- [ ] ESLint + Prettier plugin versions match target compiler syntax
+- [ ] `kit.adapter` / `kit.alias` / `kit.paths` re-validation recorded
+- [ ] Env var inventory captured
+- [ ] Deployment config files inventoried (diffed in Phase 4)
+- [ ] Co-dependent changes ordered

--- a/templates/sveltekit/upgrade-readiness/03-breaking-changes-impact.md
+++ b/templates/sveltekit/upgrade-readiness/03-breaking-changes-impact.md
@@ -1,0 +1,126 @@
+# Phase 3: Breaking Changes Impact
+
+Derive the target release's breaking-change set from its migration guide.
+Count occurrences of each affected pattern in the codebase.
+Classify effort per category and produce a priority table.
+
+## Inputs
+
+- The target release's official migration guide (primary source of breaking changes)
+- The target compiler's own migration guide (Svelte, if bumping the compiler alongside SvelteKit)
+- The codebase (`src/`, `src/routes/`)
+
+## Process
+
+### 1. Enumerate breaking-change categories
+
+Read the migration guide end-to-end. List every breaking change it documents.
+Two families typically apply to a SvelteKit upgrade:
+
+- **Compiler-level** — Svelte syntax and runtime API changes
+  (props, reactivity, events, slots, lifecycle, custom elements)
+- **SvelteKit-level** — framework API changes
+  (`error` / `redirect` / `fail` control flow, `cookies`, `$app/*` imports, `load` functions,
+  form actions, route helpers, hooks, env vars)
+
+For each category, record:
+
+- **Before pattern** (SvelteKit-1-era syntax / API)
+- **After pattern** (target syntax / API)
+- **Detection method** (how to find it — grep regex, AST query, etc.)
+- **Effort class** (mechanical / moderate / requires-redesign)
+- **Automation** (does the official migration tool handle it?)
+- **Severity** (compile-time error / runtime break / deprecation / silent behavior change)
+
+### 2. Derive detection commands
+
+For each pattern, write a grep that finds occurrences. Good grep patterns:
+
+- Match the **literal API call** or **import specifier**, not the intent
+- Restrict file types with `--include="*.svelte"` or `--include="*.ts"`
+- Use `| wc -l` for counts, `-l` for file counts
+- Anchor on unambiguous tokens (e.g. `'^\s*\$:'` not `'\$:'` to avoid false matches)
+
+Examples of the shape:
+
+```bash
+# Find a specific API call
+grep -rn "<before-api-call>" src/ --include="*.svelte" | wc -l
+
+# Find a specific import
+grep -rn "from '<old-module>'" src/ --include="*.svelte" --include="*.ts" | wc -l
+
+# Find a specific syntactic pattern (anchored)
+grep -rn "^\s*<before-syntax>" src/ --include="*.svelte" | wc -l
+```
+
+### 3. Count occurrences
+
+Run every detection command. Record:
+
+- Total occurrences
+- Files affected
+- Routes affected (if a SvelteKit API pattern)
+
+### 4. Classify effort
+
+For each category:
+
+| Class | Meaning |
+|-------|---------|
+| **Mechanical** | 1-to-1 rewrite, can be scripted or auto-migrated |
+| **Moderate** | Requires understanding semantics (cleanup, concurrency, data flow) |
+| **Requires redesign** | No automatic mapping — needs human judgment per call site |
+
+### 5. Identify runtime-break patterns
+
+Some breaking changes are **runtime errors** rather than compile-time errors.
+These are P0 blockers because nothing fails at build time but the app breaks in production.
+
+Flag every category whose pre-change form silently passes validation but fails at runtime.
+
+### 6. Check automated-migration tool coverage
+
+Most Svelte / SvelteKit upgrades ship an automated migration tool:
+
+```bash
+# Dry-run only — do not apply in this phase
+# npx sv migrate <target>       # Svelte compiler migrations
+# npx svelte-migrate <target>   # SvelteKit framework migrations
+```
+
+Record which categories the tool handles and which are left to manual work.
+
+## Output
+
+Impact summary:
+
+| Family | Pattern | Count | Effort | Auto? | Severity | Priority |
+|--------|---------|-------|--------|-------|----------|----------|
+| Compiler | ... | ___ | mechanical / moderate / redesign | yes / partial / no | build / runtime / deprecation | P0-P3 |
+| SvelteKit | ... | ___ | ... | ... | ... | ... |
+
+Plus:
+
+- Total component count
+- Total route count
+- Runtime-break blockers listed separately
+- Automated-tool coverage summary (handled vs manual)
+
+This impact table is the **direct input to a `migration` execution plan**: each row's
+before→after pattern becomes a uniform transform-rule mapping, its count seeds the checklist rows,
+and its effort/severity classes drive sequencing and priority. Do not execute the rewrites here —
+hand this table to the `migration` plan (or `refactor`, for the internal-restructure portion).
+
+## Verification
+
+- [ ] Target release's migration guide read in full
+- [ ] Every documented breaking change has a category row
+- [ ] Every category has a detection command
+- [ ] Every category has a count recorded
+- [ ] Every category has an effort class
+- [ ] Every category has an automation flag
+- [ ] Runtime-break patterns flagged as P0
+- [ ] Compiler-level and SvelteKit-level families kept distinct
+- [ ] Automated-tool coverage documented
+- [ ] Priority order set

--- a/templates/sveltekit/upgrade-readiness/04-ci-cd-changes.md
+++ b/templates/sveltekit/upgrade-readiness/04-ci-cd-changes.md
@@ -1,0 +1,173 @@
+# Phase 4: CI/CD Changes
+
+Audit pipelines, build agents, deploy scripts, adapter output, and Docker for target compatibility.
+
+## Inputs
+
+- Target release's engine and runtime requirements (from Phase 1)
+- Adapter decision and output location (from Phase 1)
+- Current pipeline, Dockerfile, and deploy configs
+
+## Process
+
+### 1. Inventory pipeline files
+
+```bash
+ls -la Jenkinsfile* .github/workflows/*.yml 2>/dev/null
+ls -la .gitlab-ci.yml .circleci/config.yml .travis.yml 2>/dev/null
+ls -la Dockerfile* docker-compose* 2>/dev/null
+ls -la Makefile deploy.sh deploy/ scripts/deploy* scripts/build* 2>/dev/null
+ls -la vercel.json netlify.toml wrangler.toml 2>/dev/null
+```
+
+Record every file, its role (build / test / deploy), and whether the target release's
+requirements touch it.
+
+### 2. Node.js version per environment
+
+```bash
+grep -n "nodejs\|node\|NodeJS\|nvm" Jenkinsfile* 2>/dev/null
+grep -n "node-version" .github/workflows/*.yml 2>/dev/null
+grep -n "FROM node\|FROM.*node" Dockerfile* 2>/dev/null
+cat .nvmrc 2>/dev/null
+```
+
+| Environment | Current | Target (from Phase 1) | Action |
+|-------------|---------|----------------------|--------|
+| CI build agent | ___ | ___ | — |
+| Docker image | ___ | ___ | — |
+| `.nvmrc` | ___ | ___ | — |
+| Dev machines | ___ | ___ | notify team |
+| Serverless runtime | ___ | ___ | — |
+
+Serverless runtime version may be forced by the adapter upgrade — check the adapter's changelog.
+
+### 3. Package manager
+
+```bash
+grep -n "pnpm\|npm\|yarn\|corepack" Jenkinsfile* .github/workflows/*.yml 2>/dev/null
+grep -n "packageManager" package.json
+```
+
+Verify the CI package manager version handles the new lockfile and `packageManager` field.
+
+### 4. Build commands
+
+```bash
+grep -A 20 '"scripts"' package.json
+grep -n "pnpm build\|npm run build\|pnpm install\|npm ci\|svelte-kit sync" \
+  Jenkinsfile* .github/workflows/*.yml 2>/dev/null
+```
+
+For each command the pipeline runs, check:
+
+- Does it still succeed after the dependency and config changes from Phase 1–2?
+- Does the target compiler emit new warnings that the pipeline treats as errors?
+- Does `svelte-check`'s new major change the exit code on any existing warnings?
+- Does `svelte-kit sync` run in the right order (before `check`, before `build`)?
+
+### 5. Adapter output validation
+
+Know the adapter's expected output shape **before** the upgrade — then verify it's unchanged
+(or document the new shape) after.
+
+```bash
+ls -la build/ .svelte-kit/output/ .vercel/output/ .netlify/ 2>/dev/null
+```
+
+For each pipeline step that reads the adapter output (deploy, upload, health check, size
+threshold), confirm the file paths still resolve.
+
+### 6. Deployment
+
+```bash
+grep -rn "deploy\|s3\|gcs\|cloudflare\|vercel deploy\|netlify deploy" \
+  Jenkinsfile* .github/workflows/*.yml scripts/ Makefile 2>/dev/null
+```
+
+| Aspect | Check |
+|--------|-------|
+| Adapter output directory | May move between adapter majors |
+| Serverless function format | May move between adapter majors |
+| Static asset routing | Usually unchanged |
+| CDN cache invalidation | Only if asset hashes change |
+| Env var injection | Re-test dynamic env vars per adapter |
+| Serverless runtime | May be forced by adapter upgrade |
+
+### 7. CI cache invalidation
+
+```bash
+grep -n "cache\|restore\|store" Jenkinsfile* .github/workflows/*.yml 2>/dev/null
+```
+
+At minimum, invalidate:
+
+- `node_modules`
+- Package manager store (`pnpm store`, etc.)
+- `.svelte-kit/` directory
+- Adapter output (build artifacts)
+- Docker layer cache (if base image changes)
+
+### 8. Dockerfile
+
+```bash
+grep -n "FROM\|RUN.*install\|RUN.*build\|COPY.*package" Dockerfile* 2>/dev/null
+```
+
+For each line, verify it still works after dep / engine changes. Common updates:
+
+- `FROM node:X` base image bumped to target minimum
+- Install command valid for new lockfile format
+- Build command produces expected output
+- Entry point (`CMD`) matches the adapter's output path
+
+### 9. Build-time environment variables
+
+```bash
+grep -n "SVELTE\|VITE_\|PUBLIC_\|NODE_ENV" Jenkinsfile* .github/workflows/*.yml .env* 2>/dev/null
+grep -rn "\$env/static\|\$env/dynamic" src/
+```
+
+Static env vars are injected at build time — verify CI still passes them.
+Dynamic env vars resolve at runtime per adapter — may need re-testing after adapter bump.
+`PUBLIC_*` prefix convention for client-exposed vars should be preserved.
+
+### 10. Rollback plan
+
+For each change, document the rollback action:
+
+| Change | Rollback |
+|--------|----------|
+| Node version bump | Revert `.nvmrc` / pipeline config |
+| Package manager version | Revert `packageManager` field |
+| Build command changes | Revert `package.json` scripts |
+| Docker base image | Revert `Dockerfile` |
+| Adapter bump | Revert adapter version — may require code revert |
+| Deployment config | Revert `vercel.json` / `netlify.toml` / `wrangler.toml` |
+
+Document whether parallel pipelines (old + new) are viable for staged rollout.
+
+## Output
+
+CI/CD change manifest:
+
+- Per-file edits
+- Version requirements per environment
+- Adapter output verification
+- Cache invalidation list
+- Deployment impact assessment
+- Rollback procedures
+
+## Verification
+
+- [ ] All pipeline files inventoried
+- [ ] Node version confirmed per environment against Phase 1 target
+- [ ] Package manager compat confirmed
+- [ ] Build commands validated
+- [ ] Adapter output location and shape confirmed
+- [ ] Deployment scripts / config reviewed
+- [ ] Cache invalidation plan recorded
+- [ ] Dockerfile updated (if applicable)
+- [ ] Serverless runtime matches adapter target
+- [ ] Rollback plan documented
+- [ ] Env vars (`$env/static` + `$env/dynamic`) preserved

--- a/templates/sveltekit/upgrade-readiness/05-validation-strategy.md
+++ b/templates/sveltekit/upgrade-readiness/05-validation-strategy.md
@@ -1,0 +1,236 @@
+# Phase 5: Validation Strategy
+
+Define pass criteria for every layer. Produce go/no-go before feature code rewrites begin.
+
+## Inputs
+
+- The runtime-break patterns flagged in Phase 3 (for dedicated smoke checks)
+- The adapter output shape from Phase 1 (for adapter-specific smoke)
+
+## Layers
+
+### 1. Dependency install
+
+```bash
+rm -rf node_modules .svelte-kit
+rm -f pnpm-lock.yaml package-lock.json yarn.lock   # remove the repo's lockfile
+<pm> install
+<pm> install 2>&1 | grep -i "peer\|warn\|error"
+<pm> list --depth 0 | grep -i "sveltejs\|svelte\|vite"
+```
+
+Pass:
+
+- [ ] Exit 0
+- [ ] Zero unresolved peer errors
+- [ ] Core packages (`@sveltejs/kit`, adapter, compiler, `@sveltejs/vite-plugin-svelte`) at target versions
+- [ ] Lockfile generated without conflicts
+
+### 2. `svelte-kit sync`
+
+```bash
+<pm> exec svelte-kit sync
+```
+
+Pass:
+
+- [ ] Exit 0
+- [ ] `.svelte-kit/tsconfig.json` regenerated
+- [ ] Type references resolve
+
+### 3. Production build
+
+```bash
+<pm> build && echo $?
+```
+
+Pass:
+
+- [ ] Exit 0
+- [ ] No compiler errors (warnings acceptable)
+- [ ] Adapter output directory populated (shape matches Phase 1 adapter decision)
+- [ ] Build time comparable to baseline
+
+### 4. Type check
+
+```bash
+<pm> check
+```
+
+Pass:
+
+- [ ] Runs without crash
+- [ ] No new type errors from infra changes
+- [ ] `svelte-check` at target version
+- [ ] Types resolve for `$app/*`, `$env/*`, `$lib/*`
+
+### 5. Lint
+
+```bash
+<pm> lint
+```
+
+Pass:
+
+- [ ] Runs without crash
+- [ ] No new lint errors from config changes
+- [ ] New compiler syntax (if any) parses
+- [ ] `eslint-plugin-svelte` parses route files (`+page.svelte`, `+layout.svelte`)
+
+### 6. Bundle comparison
+
+Capture baseline (on the pre-change branch) and change (on the upgrade branch).
+
+```bash
+<pm> build
+du -sh .svelte-kit/output/ 2>/dev/null
+find .svelte-kit/output/ -name "*.js" -exec wc -c {} + 2>/dev/null | tail -1
+```
+
+| Metric | Before | After | Δ | OK? |
+|--------|--------|-------|---|-----|
+| Total output size | ___ | ___ | ___ | |
+| Client JS total | ___ | ___ | ___ | |
+| Server JS total | ___ | ___ | ___ | |
+| Prerendered HTML count | ___ | ___ | ___ | |
+
+Thresholds:
+
+- Size increase < 20% acceptable for initial rollout (adjust per project)
+- Output layout must match the adapter's expected shape
+- Prerendered page count must be equal or greater
+
+### 7. Route + endpoint smoke test
+
+Start the app locally (via adapter-node, `<pm> preview`, or deployed preview URL):
+
+```bash
+<pm> preview &
+sleep 2
+
+# Page route
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4173/
+
+# Dynamic page route (project-specific)
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4173/{sample-page}
+
+# API endpoint (+server.ts)
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4173/api/{sample-endpoint}
+
+# Form action
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:4173/{form-route}?/default
+
+# Not-found handler
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4173/does-not-exist
+```
+
+Pass:
+
+- [ ] Home page renders (200)
+- [ ] Dynamic page route renders (200)
+- [ ] API endpoint responds (expected status)
+- [ ] Form action responds (expected status)
+- [ ] Not-found handler works
+- [ ] No runtime errors from Phase 3 runtime-break patterns
+- [ ] `load` functions return expected data (no empty first-paint)
+
+### 8. Adapter-specific smoke test
+
+Match the project's adapter:
+
+| Adapter | Smoke test |
+|---------|-----------|
+| `adapter-node` | Start the output process, health check returns 200 |
+| `adapter-static` | Every prerendered route exists as HTML, 404 fallback present |
+| `adapter-vercel` | `vercel dev` or preview deployment serves routes + functions |
+| `adapter-netlify` | `netlify dev` or preview serves functions + static |
+| `adapter-cloudflare` | `wrangler dev` serves the worker, bindings resolve |
+
+Pass:
+
+- [ ] Adapter output starts / serves correctly locally
+- [ ] Serverless function entry point matches expected format
+- [ ] `$env/dynamic/*` vars resolve at runtime (if used)
+
+### 9. Test suite
+
+```bash
+<pm> test
+<pm> test:e2e 2>/dev/null
+```
+
+Pass:
+
+- [ ] Vitest runner starts
+- [ ] Playwright runner starts (if present)
+- [ ] No new failures from infra changes alone
+- [ ] Failures caused by target-release API changes classified as code-phase work
+
+### 10. Dev server
+
+```bash
+<pm> dev
+```
+
+Pass:
+
+- [ ] Starts clean
+- [ ] Existing routes render
+- [ ] HMR works for `.svelte` files
+- [ ] `+page.server.ts` / `+server.ts` reload on change
+- [ ] No browser console errors
+
+## Go / No-Go
+
+Blockers (all must pass):
+
+- [ ] `<pm> install` — zero peer errors
+- [ ] `<pm> exec svelte-kit sync` — exit 0
+- [ ] `<pm> build` — exit 0
+- [ ] Adapter output shape matches expected layout
+- [ ] `<pm> check` runs
+- [ ] `<pm> lint` runs
+- [ ] Dev server starts + renders home + one dynamic route
+- [ ] `preview` or local adapter-output start serves routes correctly
+- [ ] No runtime errors from Phase 3 runtime-break patterns
+
+Important (not blocking):
+
+- [ ] Bundle size within threshold
+- [ ] Existing tests pass
+- [ ] HMR works
+- [ ] No new deprecation warnings
+- [ ] CI pipeline builds green
+
+## Execution order
+
+1. Clean install
+2. `svelte-kit sync`
+3. Production build
+4. Type check
+5. Lint
+6. Bundle comparison
+7. Dev server
+8. Route + endpoint smoke test
+9. Adapter-specific smoke test
+10. Test suite
+11. CI pipeline run
+
+## Output
+
+Validation report: per-layer status, bundle comparison, route/endpoint results,
+adapter output verification, failure classification (infra vs code),
+go/no-go decision with justification.
+
+## Verification
+
+- [ ] All layers have pass criteria
+- [ ] Bundle baseline recorded
+- [ ] Adapter output shape confirmed
+- [ ] Route + endpoint smoke test defined and run
+- [ ] Adapter-specific smoke test defined
+- [ ] Phase 3 runtime-break patterns have dedicated smoke checks
+- [ ] Go/no-go criteria agreed
+- [ ] Execution order documented
+- [ ] Infra vs code failures distinguished
+- [ ] CI pipeline validation included

--- a/templates/sveltekit/upgrade-readiness/QUICK-REFERENCE.md
+++ b/templates/sveltekit/upgrade-readiness/QUICK-REFERENCE.md
@@ -1,0 +1,112 @@
+# Quick Reference
+
+> This template is a **process framework**. For any change path, run the phases against
+> the target release's official migration guide.
+
+## Phase sequence
+
+| # | Phase | Primary output |
+|---|-------|----------------|
+| 1 | Dependency audit | version mapping table, peer conflict list, adapter decision |
+| 2 | Config changes | per-file diff plan |
+| 3 | Breaking changes impact | derived pattern set, counts, effort classification |
+| 4 | CI/CD changes | pipeline / adapter / deploy manifest |
+| 5 | Validation strategy | pass criteria per layer, go/no-go |
+
+## Always-needed inputs
+
+- Target release's official migration guide (primary source)
+- Adapter's own changelog (adapter major decision)
+- Current `package.json` + lockfile
+- Current `src/hooks.*`, `src/app.d.ts`, `svelte.config.js`, `vite.config.ts`, `tsconfig.json`
+
+## Detection command shapes
+
+Generic patterns — substitute the actual before-form from the target migration guide:
+
+```bash
+# Count a specific API call
+grep -rn "<api-call>" src/ --include="*.svelte" | wc -l
+
+# Count a specific import
+grep -rn "from '<old-module>'" src/ --include="*.svelte" --include="*.ts" | wc -l
+
+# Count a specific syntactic pattern (anchored)
+grep -rn "^\s*<pattern>" src/ --include="*.svelte" | wc -l
+
+# Count files affected (not occurrences)
+grep -rl "<pattern>" src/ --include="*.svelte" | wc -l
+```
+
+## Effort classes
+
+| Class | Meaning |
+|-------|---------|
+| Mechanical | 1-to-1 rewrite, scriptable or auto-migratable |
+| Moderate | Requires semantic understanding (cleanup, concurrency, data flow) |
+| Redesign | No automatic mapping — human judgment per call site |
+
+## Severity classes
+
+| Severity | Meaning |
+|----------|---------|
+| Build break | Compile-time error |
+| Runtime break | Passes build, fails in production — **always P0** |
+| Deprecation | Old form still works with warning — P2 / P3 |
+| Silent behavior change | Old form runs but semantics differ — **P0 until verified** |
+
+## Config file inventory
+
+| File | Typical concerns |
+|------|------------------|
+| `svelte.config.js` | Preprocessor import paths, compiler options, `kit.adapter`, `kit.alias`, `kit.paths` |
+| `vite.config.ts` | Plugin import, Vite version, custom plugins |
+| `tsconfig.json` | `moduleResolution`, `verbatimModuleSyntax`, version minimums, `extends` path |
+| `src/hooks.server.ts` / `hooks.client.ts` | Control-flow helpers, cookie APIs, error handlers |
+| `src/app.d.ts` | `App` namespace shapes |
+| `eslint.config.js` / `.eslintrc` | Plugin version matches target compiler syntax |
+| `.prettierrc` / `prettier.config.*` | `prettier-plugin-svelte` version |
+| `.nvmrc` / `.node-version` | Node minimum |
+| `Dockerfile` | Base image, install command, build command, entry point |
+| `vercel.json` / `netlify.toml` / `wrangler.toml` | Adapter-specific deploy config |
+
+## Go / No-Go blockers
+
+- [ ] `<pm> install` — zero peer errors
+- [ ] `<pm> exec svelte-kit sync` — exit 0
+- [ ] `<pm> build` — exit 0
+- [ ] Adapter output shape matches expected layout
+- [ ] `<pm> check` runs
+- [ ] `<pm> lint` runs
+- [ ] Dev server + `preview` serve home + one dynamic route
+- [ ] No runtime errors from Phase 3 runtime-break patterns
+
+## Validation order
+
+1. Clean install
+2. `svelte-kit sync`
+3. Production build
+4. Type check
+5. Lint
+6. Bundle comparison
+7. Dev server
+8. Route + endpoint smoke
+9. Adapter-specific smoke
+10. Tests
+11. CI pipeline
+
+## Automated migration tools
+
+If the target release ships one, use it **in dry-run only** during this phase.
+This template does not apply changes — execution belongs in a `migration` plan (external-driven code
+rewrites) or `refactor` plan (internal restructures). Record coverage; hand it to that plan.
+
+```bash
+# Svelte compiler migrations (varies by target)
+# npx sv migrate <target>
+
+# SvelteKit framework migrations (varies by target)
+# npx svelte-migrate <target>
+```
+
+Record which categories the tool handles and which are left manual.

--- a/templates/sveltekit/upgrade-readiness/README.md
+++ b/templates/sveltekit/upgrade-readiness/README.md
@@ -1,0 +1,64 @@
+# upgrade-readiness
+
+Readiness-plan process for disruptive changes in a SvelteKit project:
+SvelteKit version bump, Svelte compiler bump, core-dep bump, adapter swap, toolchain overhaul.
+
+**This template is a process framework, not a lookup table.** Phase files describe the
+*process* of auditing a major change. Concrete patterns, detection commands, and version
+maps are derived per-change from the target release's migration guide — not shipped in
+the template.
+
+## Phases
+
+| # | File | Produces |
+|---|------|----------|
+| 1 | `01-dependency-audit.md` | version mapping, peer conflicts, adapter + engine requirements |
+| 2 | `02-config-changes.md` | per-file config diff plan (svelte, vite, ts, hooks, lint/format) |
+| 3 | `03-breaking-changes-impact.md` | breaking-change set derived from target guide, counted, classified |
+| 4 | `04-ci-cd-changes.md` | pipeline, build agents, adapter-driven deploy, cache updates |
+| 5 | `05-validation-strategy.md` | install / build / check / route / adapter gates + go/no-go |
+
+## Scope
+
+- In: deps, configs, CI/CD, route + endpoint + adapter validation
+- Out: feature code rewrites — these are executed with a **`migration`** plan (external-driven
+  code changes: repoint every breaking-change site to the new API, then retire the old surface) or a
+  **`refactor`** plan (internal-driven restructures). This template produces the readiness inputs they
+  consume; see Phase 3.
+
+## Where this fits
+
+`upgrade-readiness` is the **pre-flight / go-no-go stage** of the migration family. It audits and
+quantifies the change, then hands off:
+
+- Phase 3's breaking-change impact table (before→after pattern, detection, effort, count) is the
+  direct input to a **`migration`** execution plan's mapping.
+- If the change also entails internal restructuring, that portion is executed via **`refactor`**.
+
+Run `upgrade-readiness` first; only after its go/no-go do you open the execution plan(s).
+
+## Rules
+
+- Pin exact target versions. Never use ranges.
+- **Read the target release's migration guide in full before running Phase 3.**
+  The breaking-change set is derived from it, not assumed.
+- Audit adapter compatibility before bumping `@sveltejs/kit`.
+- Svelte compiler breaking changes and SvelteKit API breaking changes are separate
+  concerns — keep them distinct in Phase 3.
+- Flag runtime-break patterns (compile silently, fail in production) as P0 regardless of effort.
+- Infra changes and code changes live in separate plans.
+
+## How to use
+
+1. Identify the change path (source release → target release).
+2. Fetch the target release's official migration guide.
+3. Run each phase in order, filling in project-specific values.
+4. Produce go/no-go at the end of Phase 5 before touching component code.
+
+## Use when
+
+- SvelteKit major version upgrade
+- Svelte compiler major upgrade inside a SvelteKit app
+- Major bump of Vite, TypeScript, or Node LTS
+- Adapter swap or deployment target change
+- Go / no-go on a disruptive change

--- a/templates/sveltekit/upgrade-readiness/meta.json
+++ b/templates/sveltekit/upgrade-readiness/meta.json
@@ -1,0 +1,27 @@
+{
+  "name": "upgrade-readiness",
+  "description": "Readiness audit and go/no-go for major SvelteKit changes: deps, configs, breaking impact, CI/CD, validation. Precedes a migration/refactor execution plan.",
+  "use_cases": [
+    "SvelteKit 1 to 2 upgrade",
+    "Svelte 4 to 5 upgrade in a SvelteKit app",
+    "major Vite / TypeScript / Node bump",
+    "adapter or deployment target change",
+    "breaking-change impact quantification",
+    "CI/CD readiness before a disruptive change",
+    "go / no-go on a large refactor or upgrade"
+  ],
+  "phases": [
+    { "file": "01-dependency-audit.md", "name": "Dependency Audit" },
+    { "file": "02-config-changes.md", "name": "Config Changes" },
+    { "file": "03-breaking-changes-impact.md", "name": "Breaking Changes Impact" },
+    { "file": "04-ci-cd-changes.md", "name": "CI/CD Changes" },
+    { "file": "05-validation-strategy.md", "name": "Validation Strategy" }
+  ],
+  "verification": [
+    { "command": "<pm> install --dry-run", "description": "Resolve dep tree without conflicts (<pm> = the repo's package manager, detected in Phase 1)" },
+    { "command": "<pm> build", "description": "Production build exits 0" },
+    { "command": "<pm> check", "description": "svelte-check passes on target versions" },
+    { "command": "<pm> lint", "description": "No new lint errors from config changes" },
+    { "command": "ls .svelte-kit/output/", "description": "Adapter output present in expected shape" }
+  ]
+}


### PR DESCRIPTION
## What

Adds `upgrade-readiness`, a SvelteKit planning template that produces a readiness audit and **go/no-go** for disruptive changes — a SvelteKit/Svelte version bump, a major core-dependency bump (Vite, TypeScript, Node LTS), an adapter swap, or a toolchain overhaul — *before* any code is touched.

## Why

Major upgrades fail when they start blind. This template front-loads the "is this feasible, how big is it, what breaks" work into a structured, quantified audit that ends in an explicit go/no-go, so the execution plan starts with a known blast radius instead of surprises.

## Phases

1. **Dependency audit** — read the target release's migration guide; map direct/dev deps to compatible versions; surface peer conflicts; pick an adapter major; record engine requirements.
2. **Config changes** — inventory every touched config (`svelte.config`, `vite.config`, `tsconfig`, hooks, `app.d.ts`, lint/format, deploy) → per-file diff plan.
3. **Breaking-changes impact** — derive the breaking-change set from the migration guide; write a detection command per category; count occurrences; classify by effort/severity; flag runtime-break patterns as P0.
4. **CI/CD changes** — audit pipelines, build agents, adapter output, Docker, deploy config, cache invalidation, rollback path.
5. **Validation strategy** — install / sync / build / check / lint / bundle / route-smoke / adapter-smoke gates → go/no-go checklist.

## Design principles

- **Process framework, not a lookup table** — concrete patterns and version maps are derived per-change from the target release's migration guide, so phase files stay valid across any future upgrade path without stale content.
- **Stack-agnostic** — the package manager is discovered in Phase 1 and referenced as `<pm>` throughout; no hardcoded `pnpm`/`npm`/`yarn`. SvelteKit-specific concerns (adapters, `svelte-kit sync`, `$app/*`) are intentionally retained.
- **Audit only, no execution** — this template does not rewrite code. Phase 3's impact table is the direct input to a **`migration`** execution plan (external-driven rewrites) or **`refactor`** plan (internal restructures); the deferrals name those explicitly.

## Where it fits

`upgrade-readiness` is the pre-flight stage of the migration family: run it first, get the go/no-go, then open the execution plan(s).

## Notes

- Registered under `templates/sveltekit` in the language `meta.json`.
- No changes to the MCP server or loader — the template is data-driven and resolves through the existing pipeline (validated: root → sveltekit → upgrade-readiness, 5 phases).
