### PR TITLE
feat(sveltekit): add refactor template

### DIFF
--- a/templates/sveltekit/meta.json
+++ b/templates/sveltekit/meta.json
@@ -11,6 +11,17 @@
         "API integration on client",
         "new feature module"
       ]
+    },
+    "migration": {
+      "description": "Plan and execute a migration in any SvelteKit codebase: replace an old externally-driven surface (a package, dependency version, tool, codegen pipeline, or framework API) with a new one across every coupled site, coordinated via a shared checklist, and retire the old surface. Stack-agnostic — the repo's tools, commands, and conventions are discovered, not assumed.",
+      "use_cases": [
+        "migrating from one package or library to another",
+        "upgrading a dependency across a breaking major version",
+        "migrating hand-written code into a codegen pipeline",
+        "adopting a new framework API or pattern tied to a version bump",
+        "repointing every consumer off a deprecated surface, then deleting it",
+        "any adopt-the-new-external-surface-and-remove-the-old-version job across many sites"
+      ]
     }
   }
 }

--- a/templates/sveltekit/meta.json
+++ b/templates/sveltekit/meta.json
@@ -22,6 +22,17 @@
         "repointing every consumer off a deprecated surface, then deleting it",
         "any adopt-the-new-external-surface-and-remove-the-old-version job across many sites"
       ]
+    },
+    "refactor": {
+      "description": "Plan and execute an internal-driven refactor in any SvelteKit codebase: reshape, rename, extract, move, or deduplicate code across every affected site while keeping observable behavior byte-for-byte identical, coordinated via a shared checklist. No external dependency, tool, or API change. Stack-agnostic — the repo's tools, commands, and conventions are discovered, not assumed.",
+      "use_cases": [
+        "extracting or splitting a module; restructuring directory layout (service to module architecture)",
+        "renaming a symbol, type, or module across the codebase",
+        "moving code to a canonical internal home and repointing consumers",
+        "deduplicating repeated helpers or types into a single canonical version",
+        "reshaping an internal API or normalizing conventions without changing behavior",
+        "any reorganize-the-code-without-changing-what-it-does job across many sites"
+      ]
     }
   }
 }

--- a/templates/sveltekit/migration/01-discover-and-scope.md
+++ b/templates/sveltekit/migration/01-discover-and-scope.md
@@ -1,0 +1,91 @@
+# Phase 1: Discover & Scope
+
+A migration template must not assume your stack. This phase reads the **target repo** to learn how it
+builds, tests, and organizes code, then pins down exactly which old surface is leaving and which new
+surface is arriving. Everything downstream references what you record here.
+
+## Objective
+
+- Discover the repo-specific **parameters** (commands, tools, conventions) the rest of the plan uses.
+- Identify the **old surface** (what is being migrated away from) and the **new surface** (what is
+  being adopted).
+- Declare the **behavior contract**: preserved, or changed with an explicit list of expected deltas.
+
+## Critical Rules
+
+1. **Record parameters, don't hardcode tools.** No later phase may name a command or path that was
+   not discovered here.
+2. **Name the old surface as a searchable token.** You must be able to `grep` for it later (import
+   specifier, symbol, package name, API call).
+3. **Decide the behavior contract now.** A migration either preserves behavior or changes it on
+   purpose — never leave this implicit.
+
+## Step 1: Discover Repo Parameters
+
+Inspect the target repo and record the results in `00-overview.md`:
+
+```bash
+# Package manager: lockfile tells you which
+ls pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null
+
+# Scripts: the real typecheck / lint / test commands
+cat package.json   # read the "scripts" block; note the exact names used
+
+# Codegen present? (only relevant to some migrations)
+grep -in "generate" package.json
+grep -rln "@generated\|DO NOT EDIT\|AUTO-GENERATED" src/ 2>/dev/null
+
+# Import conventions: aliases and barrels in use
+cat svelte.config.* vite.config.* tsconfig*.json 2>/dev/null   # path aliases (e.g. $lib)
+```
+
+Record the **Discovered Parameters** table in `00-overview.md`:
+
+| Parameter | Discovered value |
+|-----------|------------------|
+| package manager | (from lockfile) |
+| typecheck command | (from scripts) |
+| lint command | (from scripts) |
+| test command | (from scripts) |
+| codegen pipeline | present / absent (+ regenerate command) |
+| path aliases / barrels | (from config) |
+
+## Step 2: Identify Old & New Surface
+
+State both precisely:
+
+- **Old surface** — what leaves, as a token you can search for. Examples: a package name, an import
+  specifier, a symbol/API, a directory, a deprecated pattern.
+- **New surface** — what is adopted in its place, and where it lives (a package, a generated module,
+  a utils/constants location, a new API).
+
+```bash
+# Confirm the old surface is real and find its blast radius (rough count now, full inventory in Phase 2)
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js | wc -l
+```
+
+## Step 3: Declare the Behavior Contract
+
+Choose one and record it in `00-overview.md`:
+
+- **Preserved** — observable behavior must be identical. Note which existing tests are the baseline;
+  confirm they are green on the current commit *before* any change.
+- **Intentional deltas** — behavior changes on purpose (common for major dependency upgrades). List
+  each expected delta and how it will be verified. Anything not on the list must still be unchanged.
+
+```bash
+# Find the tests that currently cover the old surface (baseline)
+grep -rn "<old-surface-token>" --include=*.test.* --include=*.spec.* .
+```
+
+## Output
+
+`00-overview.md` contains: **Goal · Scope · Old surface · New surface · Discovered Parameters ·
+Behavior contract (preserved | deltas list) · Success criteria**. This is the ground truth every
+later phase and the checklist reference.
+
+## Done when
+
+Discovered parameters recorded; old and new surface named with a searchable token; behavior contract
+declared with a green baseline (or an explicit deltas list). *(Carry each of these into
+`checklist.md` per the README convention.)*

--- a/templates/sveltekit/migration/02-inventory-and-mapping.md
+++ b/templates/sveltekit/migration/02-inventory-and-mapping.md
@@ -1,0 +1,98 @@
+# Phase 2: Inventory & Mapping
+
+Turn the old surface into a complete list of **units** and decide, per unit, what happens to it. This
+is where the migration becomes concrete and idempotent: some units need full work, some only need a
+repoint, some are already done, some are dead and just get dropped.
+
+## Objective
+
+- Enumerate every **unit** coupled to the old surface (the smallest independently-repointable thing).
+- Define the **mapping** from each unit to its new form — in whichever shape fits.
+- Assign each unit a **terminal state** so no-ops and dead code are not re-worked.
+
+## Critical Rules
+
+1. **Inventory is exhaustive before execution.** A missed unit becomes a dangling reference at retire
+   time. Enumerate first, work second.
+2. **The unit is not the file.** A file may couple to the old surface in several independent places;
+   each is its own unit and its own checklist row.
+3. **Choose the mapping shape deliberately** (see Step 2) — do not force per-unit routing onto a
+   uniform codemod, or vice versa.
+
+## Step 1: Enumerate Units
+
+Using the old-surface token from Phase 1:
+
+```bash
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+```
+
+Classify what kind of unit each hit is — the classification only matters insofar as it drives the
+mapping. Common kinds and where they tend to go:
+
+| Unit kind | Typical new home (per repo — from discovery) |
+|-----------|----------------------------------------------|
+| a data type / shape | a codegen spec (if the repo has one) or a types module |
+| a transform / caster / helper fn | a utils module |
+| a default / literal value | a constants module |
+| a UI component | a components location |
+| a call-site of an old API | the equivalent new API call |
+| non-representable code (e.g. holds functions, conditional shapes) | a hand-written location — never codegen |
+
+## Step 2: Define the Mapping (pick the shape)
+
+Pick whichever matches this migration:
+
+**Per-unit routing** — each unit goes to a specific chosen destination. Good for consolidations and
+fan-outs (one source file's type/fn/constant each land in different homes).
+
+| Unit | Old location | New home |
+|------|--------------|----------|
+| `WidgetType` | old surface | types / codegen spec |
+| `castWidget` | old surface | utils |
+| `WIDGET_DEFAULTS` | old surface | constants |
+
+**Uniform transform rule** — one rule applied to every matching site. Good for package swaps,
+API-shape changes, pattern/version migrations.
+
+```text
+Rule: <old API call/pattern>  →  <new API call/pattern>
+e.g.  oldClient.get(url)       →  newClient.fetch(url)
+Applies to: every site found in Step 1.
+```
+
+Record which shape you chose in `00-overview.md`.
+
+## Step 3: Assign Terminal States (reconcile)
+
+For each unit run two checks and assign exactly one state:
+
+```bash
+# Check A — is it used anywhere live (outside dead code)?
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+
+# Check B — does the new surface already cover it?
+grep -rn "\b<Unit>\b" <new-surface-location>
+```
+
+| Terminal state | When | Action |
+|----------------|------|--------|
+| `NO-OP` | New surface already covers it AND nothing references the old one | nothing to do |
+| `REPOINT-ONLY` | New surface already covers it, but consumers still use the old | only repoint (Phase 4) |
+| `MIGRATE` | New surface does not cover it yet; unit is live | adopt new + repoint |
+| `DROP` | Nothing live uses it (Check A empty) | do not migrate; remove at retire |
+
+## Output
+
+A complete unit ledger: every unit with its kind, its mapping (destination or rule), and exactly one
+terminal state.
+
+**Materialize `checklist.md` now** — create the file in the plan directory and emit one row per unit,
+using the row schema and terminal states from the README. This file is the shared coordination spine
+for every later phase; phases 03–05 update its rows rather than re-authoring it.
+
+## Done when
+
+Every old-surface site is enumerated as a unit; the mapping shape is chosen and filled; every unit
+has exactly one terminal state; dead units are `DROP` and already-done units are `NO-OP`. *(Emit these
+as checklist rows per the README convention.)*

--- a/templates/sveltekit/migration/03-sequencing.md
+++ b/templates/sveltekit/migration/03-sequencing.md
@@ -1,0 +1,69 @@
+# Phase 3: Sequencing
+
+Some units depend on others: a type references another type, a helper uses a constant. Migrate a
+dependent before its dependency and you import from the soon-to-be-retired old surface. This phase
+produces a safe order and groups cycles that must move together.
+
+> **SKIP this phase** when units are independent (typical of uniform package/API-swap migrations
+> where each call-site stands alone). Mark it `SKIPPED` with that reason and move on.
+
+## Objective
+
+- Build the **dependency graph** over the units (including edges that cross owners).
+- Produce a **leaf-first** order.
+- Detect **cycles** and collapse each into one **combined unit** that migrates together.
+
+## Critical Rules
+
+1. **Leaf-first.** A unit is workable only once every unit it depends on is `done` (or `NO-OP`).
+2. **Cycles migrate together.** Mutually-referencing units cannot be split across PRs — each would
+   import the not-yet-migrated other. Co-migrate them as one combined unit.
+3. **Ignore dead nodes.** Remove `DROP`/`NO-OP` units before ordering.
+
+## Step 1: Extract Dependencies
+
+For each `MIGRATE`/`REPOINT-ONLY` unit, find which other in-scope units it references:
+
+```bash
+grep -n "\b\(<other-in-scope-units>\)\b" <file-defining-Unit>
+```
+
+| Unit | Depends on (in-scope units) |
+|------|-----------------------------|
+| `A` | `B`, `C` |
+| `B` | `A` |
+| `C` | — (leaf) |
+
+## Step 2: Collapse Cycles
+
+Any mutually-reachable set is a cycle → one combined unit, one PR:
+
+| Combined unit | Members | Reason |
+|---------------|---------|--------|
+| `A+B` | `A`, `B` | mutual reference |
+
+## Step 3: Leaf-First Waves
+
+Order so every unit follows its dependencies. Units in the same wave are independent and can be
+worked in parallel by different owners:
+
+```text
+Wave 1 (leaves):  C, ...
+Wave 2:           A+B (combined), ...
+Wave 3:           units depending on A/B
+```
+
+## Step 4: Label Cross-Owner Edges
+
+If an edge crosses owners (owner X's unit depends on owner Y's unit), record it — it becomes the
+`depends-on` value in the checklist and gates when that row may start.
+
+## Output
+
+A wave-ordered list of units and combined units, with cross-owner edges labeled. Feeds the
+`depends-on` column of `checklist.md`.
+
+## Done when
+
+Dead nodes removed; every remaining unit's in-scope dependencies recorded; all cycles collapsed into
+named combined units; a valid leaf-first ordering exists. *(Populate `depends-on` in the checklist.)*

--- a/templates/sveltekit/migration/04-execute-and-repoint.md
+++ b/templates/sveltekit/migration/04-execute-and-repoint.md
@@ -1,0 +1,81 @@
+# Phase 4: Execute & Repoint
+
+The repeatable ritual for taking **one unit** from `todo` to `done`. Run it per checklist row, in the
+Phase 3 wave order, using only the conventions discovered in Phase 1. It is the same loop whether one
+person runs it many times or many people each run it once.
+
+## Objective
+
+- Adopt the **new surface** for the unit (per its terminal state and mapping).
+- Repoint **every** consumer off the old surface.
+- Keep the work **parallel-safe** so concurrent owners do not serialize on shared files.
+
+## Critical Rules
+
+1. **Never edit the old surface in place.** Adopt the new surface at each site; the old surface stays
+   untouched until retire (Phase 5).
+2. **A unit is not `done` while any consumer still uses the old surface for it.** Repoint everything.
+3. **Split shared imports; do not rewrite them wholesale.** Editing a shared barrel for every unit
+   serializes the team — change only the one line your unit needs.
+
+## The Ritual (per unit)
+
+### Step 0: Confirm state & dependencies
+
+Confirm the row's terminal state and that all `depends-on` rows are `done`.
+`NO-OP` → check off with a note, stop. `DROP` → nothing now (retire removes it), stop.
+
+### Step 1: Adopt the new surface
+
+- `MIGRATE`: create the unit at its new home (write the codegen spec entry / add to utils / constants
+  / types, or call the new API), per the mapping from Phase 2. If the new home is a partially-covering
+  codegen artifact, add only what is missing (Phase 2 Check B).
+- `REPOINT-ONLY`: the new surface already covers it — skip authoring, go to Step 3.
+
+### Step 2: Regenerate if codegen
+
+If the new home is a generated artifact, regenerate now using the discovered command and follow the
+codegen hygiene rules (see QUICK-REFERENCE): rebase → regenerate → resolve, one unit per PR, never
+hand-edit generated output.
+
+### Step 3: Find every consumer
+
+```bash
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+```
+
+### Step 4: Repoint consumers + split shared imports
+
+Point each consumer at the new surface. Split shared/barrel imports so unrelated units don't collide:
+
+```typescript
+// BEFORE — one shared import; every unit's repoint touches this line
+import { WidgetType, Money, castWidget } from '<old-surface>';
+
+// AFTER — split; only the migrated unit moves, one line changes per unit
+import { WidgetType } from '<new-home>';        // migrated this row
+import { Money, castWidget } from '<old-surface>';  // still old, other rows
+```
+
+This lets two owners repoint two units in the same consumer file with minimal conflict, and keeps each
+row's diff reviewable in isolation.
+
+### Step 5: Record any surface-specific flags
+
+If the new surface needs per-unit options (e.g. a generator's nullability/optional handling, or an
+API's changed defaults), record them on the checklist row so a reviewer sees the choice was deliberate.
+
+### Step 6: Verify the unit
+
+Run the per-unit verification (Phase 5, Part A) before marking the row `in-review`/`done`.
+
+## Output
+
+Per unit: the new-surface artifact adopted, every consumer repointed, shared imports split, and the
+checklist row advanced. The old surface is untouched.
+
+## Done when
+
+For each unit: terminal state honored; new surface adopted (or confirmed already covering); every
+consumer repointed off the old surface; shared imports split, not wholesale-rewritten; old surface
+unchanged. *(Advance the row's `status` in the checklist.)*

--- a/templates/sveltekit/migration/05-verify-and-retire.md
+++ b/templates/sveltekit/migration/05-verify-and-retire.md
@@ -1,0 +1,86 @@
+# Phase 5: Verify & Retire
+
+Two gates and a cutover. The **per-unit gate** runs before each row is `done`. The **global gate**
+runs once, after every row is done, and is the only thing that unlocks **retire** — the atomic removal
+of the old surface. Retire before the global gate passes and you leave dangling references; retire is
+the last thing that happens, and it happens all at once.
+
+## Objective
+
+- Verify each unit against the **declared behavior contract** using the **discovered** commands.
+- Pass the **global gate**: zero references to the old surface remain where they should not.
+- **Retire** the old surface atomically.
+
+## Critical Rules
+
+1. **Verify against the contract from Phase 1.** Preserved → the baseline tests still pass unchanged.
+   Intentional deltas → each listed delta is confirmed and nothing off-list changed.
+2. **The global gate is a hard precondition for retire.** No "clean up later."
+3. **Retire is atomic and wholesale.** Remove the entire old surface in one PR — never trickle-remove,
+   which reintroduces half-migrated state.
+
+## Part A: Per-Unit Gate (per row, from Phase 4 Step 6)
+
+Run the repo's discovered commands:
+
+```bash
+<typecheck>   # must be clean
+<lint>        # no dangling imports off the old surface
+<test>        # behavior contract holds (baseline green, or expected deltas match)
+```
+
+Plus the per-unit no-lingering check:
+
+```bash
+# No consumer still reaches this unit through the old surface
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+# Expect: only the new-surface definition; nothing via the old surface
+```
+
+Per-unit checklist: typecheck clean · tests match the contract · no consumer uses the old surface for
+this unit · new surface is the single source of truth · row marked `done`.
+
+## Part B: Global Gate (once, after all rows done)
+
+Every non-`DROP`/`NO-OP` row is `done`. Now prove the old surface is fully orphaned:
+
+```bash
+# Zero references to the old surface where it should no longer appear
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+# Expect: nothing (or only the old surface's own files, about to be removed).
+
+# Also check barrels, path aliases, and dependency manifests
+grep -rn "<old-surface-token>" src/**/index.* svelte.config.* vite.config.* tsconfig*.json package.json 2>/dev/null
+```
+
+Global gate checklist: all rows `done` · repo-wide grep clean · no barrel re-exports the old surface ·
+aliases/manifest no longer reference it · full `<typecheck> && <lint> && <test>` green on the
+integrated branch.
+
+## Part C: Retire (only when Part B passes)
+
+In a single PR:
+
+```bash
+# Remove the old surface wholesale — delete files, and drop the dependency if it was a package
+git rm -r <old-surface-path>
+# If the old surface was a package, remove it from the manifest and update the lockfile
+<package-manager> remove <old-package>
+```
+
+- Remove now-dead path aliases pointing at the old surface.
+- Re-run the full discovered suite on the retire PR; it must be green with the old surface gone.
+
+Retire checklist: old surface removed in one PR · dead aliases/manifest entries cleaned · full suite
+green **after** removal · retire row in `checklist.md` marked `done`.
+
+## Output
+
+Every unit verified and `done`, the global gate passed, and the old surface atomically retired. The
+migration is complete and satisfies its declared behavior contract.
+
+## Done when
+
+Per-unit gate passed for every row; global gate clean; old surface removed atomically in one PR; full
+discovered suite green with it gone; the Phase 1 behavior contract holds end-to-end. *(Check the gate
+and retire rows in the checklist.)*

--- a/templates/sveltekit/migration/QUICK-REFERENCE.md
+++ b/templates/sveltekit/migration/QUICK-REFERENCE.md
@@ -1,0 +1,71 @@
+# Migration — Quick Reference
+
+## Is it a migration?
+
+> **Migration = external driver** (package, dep version, tool, codegen, framework API) → adopt the new
+> surface everywhere and **retire the old**. Behavior preserved *or* intentionally changed.
+> **Refactor = internal driver**, behavior invariant, nothing retired → use the `refactor` template.
+
+package swap · dep major upgrade · hand-written→codegen · framework-API/version pattern change → all
+migration, differing only in what old→new surface discovery finds.
+
+## Core invariant
+
+**Old surface fully replaced and retired.** Done = every site on the new surface + zero references to
+the old. (Behavior contract is a separate Phase-1 choice: preserved, or an explicit deltas list.)
+
+## Discover, never assume
+
+Phase 1 reads the repo for: package manager · typecheck/lint/test commands · codegen presence ·
+path aliases/barrels. Every later phase uses these params — no hardcoded tools.
+
+## Phases
+
+| Phase | Does |
+|-------|------|
+| 1 Discover & Scope | detect params · name old/new surface · declare behavior contract → `00-overview.md` |
+| 2 Inventory & Mapping | enumerate units · pick mapping shape · assign terminal states |
+| 3 Sequencing | dependency order, cycles → combined units (SKIP if independent) |
+| 4 Execute & Repoint | adopt new surface · repoint consumers · split shared imports |
+| 5 Verify & Retire | per-unit gate · global gate · atomic retire |
+
+## Mapping shapes (pick one)
+
+- **Per-unit routing** — each unit → a chosen home (type→spec/types, fn→utils, const→constants).
+- **Uniform transform rule** — `old API/pattern → new API/pattern` applied to N sites.
+
+## Terminal states
+
+`MIGRATE` (adopt new + repoint) · `REPOINT-ONLY` (new exists, only repoint) · `DROP` (dead — remove) ·
+`NO-OP` (already on new surface).
+
+## Checklist = the spine (multi-person coordination)
+
+One unit = one row = one line. `| # | unit | old→new | terminal | owner | depends-on | status | PR |`
+Status: `todo → claimed → in-progress → in-review → done`. Gate rows unlock only when all units `done`.
+**Merge discipline:** claim only your row · never reflow/re-sort · append your PR link.
+
+## Codegen hygiene (only if new home is a committed generated artifact)
+
+Never hand-edit generated output · rebase → regenerate → resolve before each push · one unit per PR ·
+record per-unit generator flags (nullability, optional handling) on the checklist row.
+
+## Repoint safely (Phase 4)
+
+```typescript
+// split shared imports so parallel rows don't collide — one line per unit
+import { WidgetType } from '<new-home>';           // migrated
+import { Money } from '<old-surface>';             // still old, other rows
+```
+
+## Global gate before retire
+
+```bash
+grep -rn "<old-surface-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+# expect nothing → then: git rm -r <old-surface-path> ; <pm> remove <old-package>
+```
+
+## Verify
+
+Run the **discovered** `<typecheck> · <lint> · <test>` against the declared behavior contract, plus
+the global-gate grep.

--- a/templates/sveltekit/migration/README.md
+++ b/templates/sveltekit/migration/README.md
@@ -1,0 +1,104 @@
+# Migration Template
+
+Plan and execute a **migration** in any SvelteKit codebase: replace an old, externally-driven
+surface with a new one across every site that touches it, coordinate the work across one or more
+people via a shared checklist, and retire the old surface once nothing references it.
+
+This template is **stack-agnostic**. It never assumes a package manager, codegen tool, test runner,
+or directory layout — every such detail is **discovered from the target repo** in Phase 1 and
+referenced as a parameter thereafter.
+
+## What counts as a migration (vs a refactor)
+
+> **Migration = the driver is external.** A new package, dependency version, tool, codegen pipeline,
+> or framework API. There is an old externally-coupled surface to leave and a new one to adopt, and
+> you **end by retiring the old coupling**. Behavior may be preserved or may shift intentionally.
+>
+> **Refactor = the driver is internal** (readability, structure, dedup). No external surface changes,
+> behavior is invariant, nothing external is retired. Use the `refactor` template for that.
+
+Examples that belong here: package swap, dependency major upgrade, hand-written → codegen, adopting a
+framework API tied to a version bump. These differ only in *what old→new surface* Phase 1 discovers —
+they are **not** separate templates.
+
+## Core Invariant
+
+**The old surface is fully replaced and retired.** The migration is done only when every coupled
+site uses the new surface and zero references to the old surface remain. This — not
+behavior-preservation — is the contract at the center. (Behavior preservation is a *per-migration
+choice*, declared in Phase 1: preserved, or changed with an explicit list of expected deltas.)
+
+## Principles
+
+1. **Discover, never assume.** Commands, tools, destinations, and conventions come from the target
+   repo (Phase 1), not from this template.
+2. **The unit is the smallest independently-repointable thing** — a symbol, a call-site, an import —
+   not a whole file. One file often couples to the old surface in several independent places.
+3. **The mapping is general.** "Where does each unit go" can be *per-unit routing* (unit → a chosen
+   destination) or a *uniform transform rule* (old API → new API applied to N sites). Pick the shape
+   that fits; the template does not force one.
+4. **Never edit the old surface in place.** Adopt the new surface at each site; remove the old surface
+   wholesale in the final phase.
+5. **The checklist is the spine.** For any migration touched by more than one person, `checklist.md`
+   is the single shared, committed coordination artifact. Everything else is read-only methodology.
+6. **Global gate before retire.** The old surface is deleted only after a repo-wide check shows no
+   remaining references.
+
+## Phases
+
+1. **Discover & Scope** — detect repo parameters (typecheck/lint/test commands, package manager,
+   import conventions, codegen presence); identify the **old** and **new** surface; declare the
+   behavior contract (preserved, or the list of intended deltas). Fills `00-overview.md`.
+2. **Inventory & Mapping** — enumerate every site coupled to the old surface; define the mapping
+   (per-unit routing or uniform rule); assign each unit a reconcile terminal state.
+3. **Sequencing** — order units by dependency, leaf-first, grouping cycles; *SKIP* when units are
+   independent.
+4. **Execute & Repoint** — the per-unit ritual: adopt the new surface, repoint consumers, keep the
+   work parallel-safe — all using the discovered conventions.
+5. **Verify & Retire** — verify with the discovered commands against the declared behavior contract,
+   pass the global gate, and retire the old surface atomically.
+
+## The Shared Checklist Convention
+
+`checklist.md` (generated into the plan) is where a team coordinates. It is authored once here and
+reused by the `refactor` template. It rides *with the artifact* so co-editors see the rules where
+they work.
+
+**Row schema — one unit per row, one row per line:**
+
+```markdown
+| # | unit | old→new | terminal | owner | depends-on | status | PR |
+|---|------|---------|----------|-------|-----------|--------|----|
+| 1 | castWidget | old caster → utils | MIGRATE | @a | — | todo | — |
+| 2 | WIDGET_DEFAULTS | old default → constants | MIGRATE | @b | — | todo | — |
+```
+
+**Terminal states:** `MIGRATE` (adopt new + repoint) · `REPOINT-ONLY` (new already exists, only
+repoint consumers) · `DROP` (nothing live uses it — remove, don't migrate) · `NO-OP` (already fully
+on the new surface).
+
+**Status lifecycle:** `todo → claimed → in-progress → in-review → done`.
+
+**Gate rows** (unlock only when all unit rows are `done`): source-immutability holds · global gate
+passes · retire.
+
+**Merge discipline (why concurrent editing stays conflict-free):** one unit = one row = one line;
+claim by editing only your row; never reflow or re-sort the table; append your PR link. Independent
+lines mean two owners rarely touch the same line.
+
+> Note: the MCP loader serves only each template's own README/phases/QUICK-REFERENCE — there is no
+> cross-template include. "Shared with `refactor`" means the same authored convention text, kept
+> consistent by hand.
+
+## When to Use
+
+- Swapping a package/library for another across the codebase
+- A breaking dependency upgrade that touches many call-sites
+- Moving hand-written code into a codegen pipeline
+- Adopting a framework API/pattern tied to a version bump
+- Any job that ends with "…and delete the old version"
+
+## When NOT to Use
+
+- Internal reshaping with no external surface change and invariant behavior → use `refactor`
+- Building something new with no existing surface → use `client-module`

--- a/templates/sveltekit/migration/meta.json
+++ b/templates/sveltekit/migration/meta.json
@@ -1,0 +1,26 @@
+{
+  "name": "migration",
+  "description": "Plan and execute a migration in any SvelteKit codebase: replace an old externally-driven surface (a package, dependency version, tool, codegen pipeline, or framework API) with a new one across every coupled site, coordinated via a shared checklist, and retire the old surface. Stack-agnostic — the repo's tools, commands, and conventions are discovered, not assumed.",
+  "use_cases": [
+    "migrating from one package/library to another (e.g. one HTTP client, date lib, or UI kit to another)",
+    "upgrading a dependency across a breaking major version",
+    "migrating hand-written code into a codegen pipeline",
+    "adopting a new framework API or pattern tied to a version bump (e.g. a runes-style rewrite)",
+    "moving a coupled surface to a new tool or convention and retiring the old one",
+    "repointing every consumer off a deprecated surface, then deleting it",
+    "any 'adopt the new external surface and remove the old version' job across many sites"
+  ],
+  "phases": [
+    { "file": "01-discover-and-scope.md", "name": "Discover & Scope" },
+    { "file": "02-inventory-and-mapping.md", "name": "Inventory & Mapping" },
+    { "file": "03-sequencing.md", "name": "Sequencing" },
+    { "file": "04-execute-and-repoint.md", "name": "Execute & Repoint" },
+    { "file": "05-verify-and-retire.md", "name": "Verify & Retire" }
+  ],
+  "verification": [
+    { "command": "<typecheck>", "description": "The repo's typecheck command, detected in Phase 1 (e.g. a svelte-check script) — must be clean" },
+    { "command": "<lint>", "description": "The repo's lint command, detected in Phase 1 — catches dangling imports off the old surface" },
+    { "command": "<test>", "description": "The repo's test command, detected in Phase 1 — proves the migration's behavior contract (preserved, or matching the expected deltas)" },
+    { "command": "grep -rn \"<old-surface-token>\" src/ --include=*.ts --include=*.svelte --include=*.js", "description": "Global gate before retire: zero references to the old surface remain anywhere it should not" }
+  ]
+}

--- a/templates/sveltekit/refactor/01-discover-and-scope.md
+++ b/templates/sveltekit/refactor/01-discover-and-scope.md
@@ -1,0 +1,95 @@
+# Phase 1: Discover & Scope
+
+A refactor template must not assume your stack. This phase reads the **target repo** to learn how it
+builds and tests, pins down the current shape and the target shape, and — most importantly — establishes
+the **behavior-invariance baseline** the whole refactor is checked against. A refactor with no baseline
+is a hope, not a plan.
+
+## Objective
+
+- Discover the repo-specific **parameters** (commands, tools, conventions) the rest of the plan uses.
+- Define the **current shape**, the **target shape**, and the **refactor kind**.
+- Establish the **behavior-invariance baseline** — and add characterization tests where coverage is thin.
+
+## Critical Rules
+
+1. **Record parameters, don't hardcode tools.** No later phase may name a command or path that was not
+   discovered here.
+2. **Behavior is invariant — there is no "deltas" option.** Unlike a migration, a refactor never
+   intentionally changes behavior. If it must, that is a separate change (see Principle 4).
+3. **The baseline is a precondition.** You cannot safely refactor code whose behavior is not pinned by
+   tests. Where it is not, add characterization tests *before* touching the code.
+
+## Step 1: Discover Repo Parameters
+
+Inspect the target repo and record the results in `00-overview.md`:
+
+```bash
+# Package manager: lockfile tells you which (<pm> throughout the plan)
+ls pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null
+
+# Scripts: the real typecheck / lint / test commands
+cat package.json   # read the "scripts" block; note the exact names used
+
+# Test framework + coverage: how behavior is pinned
+grep -iE "vitest|playwright|jest|@testing-library" package.json
+grep -in "coverage" package.json
+
+# Import conventions: aliases and barrels in use
+cat svelte.config.* vite.config.* tsconfig*.json 2>/dev/null   # path aliases (e.g. $lib)
+```
+
+Record the **Discovered Parameters** table in `00-overview.md`:
+
+| Parameter | Discovered value |
+|-----------|------------------|
+| package manager | (from lockfile) |
+| typecheck command | (from scripts) |
+| lint command | (from scripts) |
+| test command | (from scripts) |
+| test framework / coverage | (from deps) |
+| path aliases / barrels | (from config) |
+
+## Step 2: Define Current Shape, Target Shape, Refactor Kind
+
+State all three precisely in `00-overview.md`:
+
+- **Current shape** — how the in-scope code is organized today (the surface you will search over).
+- **Target shape** — the exact end-state you are reshaping toward.
+- **Refactor kind** — one or more of: `extract` · `rename` · `move` · `restructure` · `dedup` ·
+  `normalize`. This drives the mapping shape in Phase 2.
+
+```bash
+# Confirm the in-scope surface is real and get a rough size (full inventory in Phase 2)
+grep -rn "<in-scope-token>" src/ --include=*.ts --include=*.svelte --include=*.js | wc -l
+```
+
+## Step 3: Establish the Behavior-Invariance Baseline
+
+The refactor is only as safe as the tests that pin the affected behavior.
+
+```bash
+# Find the tests that currently cover the in-scope code
+grep -rn "<in-scope-token>" --include=*.test.* --include=*.spec.* .
+
+# Run the suite now and capture the result — this is the frozen baseline
+<test>
+```
+
+- Confirm the baseline is **green** on the current commit before any change.
+- Judge coverage: does the suite actually exercise the observable behavior of the in-scope code?
+- **If coverage is thin**, add **characterization tests** (tests that assert current behavior as-is,
+  not desired behavior) so the refactor has something to be verified against. Record what you added.
+- Note any behavior that is hard to pin (side effects, timing, I/O) and how you will observe it.
+
+## Output
+
+`00-overview.md` contains: **Goal · Scope · Current shape · Target shape · Refactor kind · Discovered
+Parameters · Behavior-invariance baseline (suite result + characterization tests added) · Success
+criteria**. This is the ground truth every later phase and the checklist reference.
+
+## Done when
+
+Discovered parameters recorded; current and target shape defined with a chosen refactor kind; the
+behavior-invariance baseline is green and sufficient (characterization tests added where coverage was
+thin). *(Carry each of these into `checklist.md` per the README convention.)*

--- a/templates/sveltekit/refactor/02-inventory-and-mapping.md
+++ b/templates/sveltekit/refactor/02-inventory-and-mapping.md
@@ -1,0 +1,90 @@
+# Phase 2: Inventory & Mapping
+
+Turn the in-scope surface into a complete list of **units** and decide, per unit, what happens to it.
+This is where the refactor becomes concrete and idempotent: some units need reshaping, some need moving,
+some are already in the target shape, and some are dead and just get dropped.
+
+## Objective
+
+- Enumerate every **unit** in scope (the smallest independently-changeable thing).
+- Define the **mapping** from each unit to its target form — in whichever shape fits.
+- Assign each unit a **terminal state**, then **materialize `checklist.md`**.
+
+## Critical Rules
+
+1. **Inventory is exhaustive before execution.** A missed unit becomes a dangling reference at cleanup
+   time. Enumerate first, work second.
+2. **The unit is not the file.** A file may hold several independent units; each is its own unit and its
+   own checklist row.
+3. **Choose the mapping shape deliberately** (see Step 2) — do not force a per-unit map onto a uniform
+   normalization, or vice versa.
+
+## Step 1: Enumerate Units
+
+Using the in-scope token(s) from Phase 1:
+
+```bash
+grep -rn "<in-scope-token>" src/ --include=*.ts --include=*.svelte --include=*.js
+```
+
+Record what each unit is (a type, a function, a constant, a component, a call-site) — this informs its
+target and terminal state.
+
+## Step 2: Define the Mapping (pick the shape)
+
+Pick whichever matches this refactor:
+
+**Per-unit mapping** — each unit gets a specific target. Good for renames, moves, and extractions.
+
+| Unit | Current | Target |
+|------|---------|--------|
+| `formatWidget` | `$lib/misc.ts` | rename → `formatWidgetLabel` (same file) |
+| `widgetHelpers` | `$lib/misc.ts` | move → `$lib/widgets/utils.ts` |
+| `WidgetRow` | `routes/+page.svelte` | extract → `$lib/widgets/WidgetRow.svelte` |
+
+**Uniform rule** — one rule applied to every matching site. Good for normalizations and pattern cleanups.
+
+```text
+Rule: <current form>  →  <target form>
+e.g.  default export   →  named export
+Applies to: every site found in Step 1.
+```
+
+Record which shape you chose in `00-overview.md`.
+
+## Step 3: Assign Terminal States (reconcile)
+
+For each unit run two checks and assign exactly one state:
+
+```bash
+# Check A — is it used anywhere live (outside dead code)?
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+
+# Check B — is it already in the target shape?
+# (already renamed / already at the target path / already the canonical copy)
+```
+
+| Terminal state | When | Action |
+|----------------|------|--------|
+| `NO-OP` | Already in the target shape | nothing to do |
+| `TRANSFORM` | Reshape/rename in place; unit is live | apply the transform + repoint (Phase 4) |
+| `RELOCATE` | Move/extract to a new internal home; unit is live | move + repoint; remove old location at cleanup |
+| `DROP` | Dead, or a now-redundant duplicate (Check A empty, or superseded by a canonical unit) | do not reshape; remove at cleanup |
+
+> Deduplication: point every consumer at the canonical unit (`RELOCATE`/`TRANSFORM` on the consumers),
+> then mark the redundant copies `DROP`.
+
+## Output
+
+A complete unit ledger: every unit with its action, its mapping (target or rule), and exactly one
+terminal state.
+
+**Materialize `checklist.md` now** — create the file in the plan directory and emit one row per unit,
+using the row schema and terminal states from the README. This file is the shared coordination spine for
+every later phase; phases 03–05 update its rows rather than re-authoring it.
+
+## Done when
+
+Every in-scope site is enumerated as a unit; the mapping shape is chosen and filled; every unit has
+exactly one terminal state; dead/redundant units are `DROP` and already-shaped units are `NO-OP`.
+*(Emit these as checklist rows per the README convention.)*

--- a/templates/sveltekit/refactor/03-sequencing.md
+++ b/templates/sveltekit/refactor/03-sequencing.md
@@ -1,0 +1,69 @@
+# Phase 3: Sequencing
+
+Some units depend on others: a type references another type, a helper uses a constant. Reshape or move a
+dependent before its dependency and you break the build or leave imports pointing at a not-yet-moved
+unit. This phase produces a safe order and groups cycles that must move together.
+
+> **SKIP this phase** when units are independent (typical of a uniform normalization where each site
+> stands alone). Mark it `SKIPPED` with that reason and move on.
+
+## Objective
+
+- Build the **dependency graph** over the units (including edges that cross owners).
+- Produce a **leaf-first** order.
+- Detect **cycles** and collapse each into one **combined unit** that moves together.
+
+## Critical Rules
+
+1. **Leaf-first.** A unit is workable only once every unit it depends on is `done` (or `NO-OP`).
+2. **Cycles move together.** Mutually-referencing units cannot be split across PRs — each would import
+   the not-yet-moved other. Co-work them as one combined unit.
+3. **Ignore dead nodes.** Remove `DROP`/`NO-OP` units before ordering.
+
+## Step 1: Extract Dependencies
+
+For each `TRANSFORM`/`RELOCATE` unit, find which other in-scope units it references:
+
+```bash
+grep -n "\b\(<other-in-scope-units>\)\b" <file-defining-Unit>
+```
+
+| Unit | Depends on (in-scope units) |
+|------|-----------------------------|
+| `A` | `B`, `C` |
+| `B` | `A` |
+| `C` | — (leaf) |
+
+## Step 2: Collapse Cycles
+
+Any mutually-reachable set is a cycle → one combined unit, one PR:
+
+| Combined unit | Members | Reason |
+|---------------|---------|--------|
+| `A+B` | `A`, `B` | mutual reference |
+
+## Step 3: Leaf-First Waves
+
+Order so every unit follows its dependencies. Units in the same wave are independent and can be worked
+in parallel by different owners:
+
+```text
+Wave 1 (leaves):  C, ...
+Wave 2:           A+B (combined), ...
+Wave 3:           units depending on A/B
+```
+
+## Step 4: Label Cross-Owner Edges
+
+If an edge crosses owners (owner X's unit depends on owner Y's unit), record it — it becomes the
+`depends-on` value in the checklist and gates when that row may start.
+
+## Output
+
+A wave-ordered list of units and combined units, with cross-owner edges labeled. Feeds the `depends-on`
+column of `checklist.md`.
+
+## Done when
+
+Dead nodes removed; every remaining unit's in-scope dependencies recorded; all cycles collapsed into
+named combined units; a valid leaf-first ordering exists. *(Populate `depends-on` in the checklist.)*

--- a/templates/sveltekit/refactor/04-execute-and-transform.md
+++ b/templates/sveltekit/refactor/04-execute-and-transform.md
@@ -1,0 +1,83 @@
+# Phase 4: Execute & Transform
+
+The repeatable ritual for taking **one unit** from `todo` to `done`. Run it per checklist row, in the
+Phase 3 wave order, using only the conventions discovered in Phase 1. Every unit's change must be
+**behavior-preserving** and is checked against the Phase-1 baseline before it is `done`.
+
+## Objective
+
+- Apply the unit's **transform or relocation** (per its terminal state and mapping).
+- Repoint **every** consumer to the new name/location.
+- Keep the work **parallel-safe**, and confirm behavior is unchanged after each unit.
+
+## Critical Rules
+
+1. **Behavior-preserving per unit.** After each unit, the Phase-1 baseline must still be green with no
+   change to expected outputs. If it isn't, you changed behavior — revert and reconsider.
+2. **Never mix in a behavior change.** If you spot a bug or a needed semantic change, split it into a
+   separate, non-refactor change — do not fold it into a refactor unit.
+3. **Split shared imports; do not rewrite them wholesale.** Editing a shared barrel for every unit
+   serializes the team — change only the one line your unit needs.
+
+## The Ritual (per unit)
+
+### Step 0: Confirm state & dependencies
+
+Confirm the row's terminal state and that all `depends-on` rows are `done`.
+`NO-OP` → check off with a note, stop. `DROP` → nothing now (cleanup removes it), stop.
+
+### Step 1: Apply the transform / relocation
+
+- `TRANSFORM`: reshape or rename the unit in place (rename the symbol, change the signature shape, inline,
+  normalize), per the mapping from Phase 2. Behavior of the unit itself must not change.
+- `RELOCATE`: create the unit at its new internal home (move the definition / extract into a new file);
+  leave the old location in place for now — it is removed at cleanup once nothing references it.
+
+### Step 2: Find every consumer
+
+```bash
+grep -rn "\b<Unit>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+```
+
+### Step 3: Repoint consumers + split shared imports
+
+Point each consumer at the new name/location. Split shared/barrel imports so unrelated units don't
+collide:
+
+```typescript
+// BEFORE — one shared import; every unit's repoint touches this line
+import { formatWidget, widgetHelpers, Money } from '$lib/misc';
+
+// AFTER — split; only the changed unit moves, one line changes per unit
+import { formatWidgetLabel } from '$lib/misc';        // renamed this row
+import { widgetHelpers, Money } from '$lib/misc';     // untouched, other rows
+```
+
+This lets two owners repoint two units in the same consumer file with minimal conflict, and keeps each
+row's diff reviewable in isolation.
+
+### Step 4: Confirm behavior held
+
+Run the Phase-1 baseline (or the subset covering this unit) plus the discovered checks:
+
+```bash
+<test>        # baseline still green — no expected-output changes
+<typecheck>   # clean
+```
+
+If anything went red that is not a pure mechanical fix (an import path), you changed behavior — back out.
+
+### Step 5: Advance the row
+
+Mark the checklist row `in-review`/`done`. The old location (for `RELOCATE`) stays until Phase 5.
+
+## Output
+
+Per unit: the transform/relocation applied, every consumer repointed, shared imports split, behavior
+confirmed unchanged, and the checklist row advanced.
+
+## Done when
+
+For each unit: terminal state honored (`NO-OP`/`DROP` short-circuited); transform/relocation applied;
+every consumer repointed; shared imports split, not wholesale-rewritten; the Phase-1 baseline still green.
+*(Advance the row's `status` in the checklist.)*

--- a/templates/sveltekit/refactor/05-verify-and-cleanup.md
+++ b/templates/sveltekit/refactor/05-verify-and-cleanup.md
@@ -1,0 +1,85 @@
+# Phase 5: Verify & Cleanup
+
+Two gates and an internal cleanup. The **per-unit gate** runs before each row is `done`. The **global
+gate** runs once, after every row is done, and confirms the whole refactor left behavior byte-for-byte
+identical. Only then do you **clean up** the emptied old locations and dead code. Unlike a migration,
+nothing *external* is retired — cleanup is internal housekeeping.
+
+## Objective
+
+- Verify each unit against the **frozen Phase-1 baseline**.
+- Pass the **global gate**: full suite matches the baseline; no references to old internal locations.
+- **Clean up** relocated-from locations and dropped dead code.
+
+## Critical Rules
+
+1. **Behavior is the acceptance test.** The full suite must match the Phase-1 baseline exactly — same
+   passes, same outputs. A new failure or a changed assertion means behavior moved; that is a defect,
+   not a refactor.
+2. **The global gate precedes cleanup.** Do not remove an old location while anything still imports it.
+3. **Cleanup is internal only.** Remove emptied files, dead code, and stale internal aliases — never a
+   dependency or an external surface (that would make this a migration).
+
+## Part A: Per-Unit Gate (per row, from Phase 4 Step 4)
+
+Run the repo's discovered commands:
+
+```bash
+<typecheck>   # must be clean
+<lint>        # no dangling imports off the old name/location
+<test>        # matches the Phase-1 baseline for this unit's behavior
+```
+
+Per-unit checklist: typecheck clean · behavior matches baseline · no consumer uses the old name/location ·
+row marked `done`.
+
+## Part B: Global Gate (once, after all rows done)
+
+Every non-`DROP`/`NO-OP` row is `done`. Now prove the refactor as a whole preserved behavior and left no
+dangling references:
+
+```bash
+# Behavior invariant: the FULL suite matches the frozen Phase-1 baseline (same passes, same outputs)
+<test>
+
+# No references remain to any relocated/renamed unit's old path or old name
+grep -rn "<old-internal-path>" src/ --include=*.ts --include=*.svelte --include=*.js
+grep -rn "\b<old-name>\b" src/ --include=*.ts --include=*.svelte --include=*.js
+# Expect: nothing outside the old location itself (which is about to be removed).
+
+# Barrels / aliases no longer re-export the old path
+grep -rn "<old-internal-path>" src/**/index.* svelte.config.* vite.config.* tsconfig*.json 2>/dev/null
+```
+
+Global gate checklist: all rows `done` · full `<test>` matches baseline · `<typecheck>` + `<lint>` clean ·
+no refs to old locations/names · no barrel/alias re-exports the old path.
+
+## Part C: Cleanup (only when Part B passes)
+
+In a single PR (or a small final batch):
+
+```bash
+# Remove emptied old locations (for RELOCATE units) and dead code (for DROP units)
+git rm <emptied-old-file>
+# Remove now-dead internal path aliases pointing at old locations
+```
+
+- Delete `DROP` units (dead code, redundant duplicates).
+- Remove now-empty files/directories left behind by `RELOCATE`.
+- Re-run the full discovered suite after cleanup — it must still match the baseline with the old
+  locations gone.
+
+Cleanup checklist: emptied old locations removed · dead/duplicate code deleted · stale internal aliases
+removed · full suite matches baseline **after** cleanup · cleanup row in `checklist.md` marked `done`.
+
+## Output
+
+Every unit verified and `done`, the global gate passed (behavior byte-for-byte identical to the
+baseline), and old internal locations and dead code cleaned up. The refactor is complete and provably
+behavior-preserving.
+
+## Done when
+
+Per-unit gate passed for every row; global gate clean (full suite matches the Phase-1 baseline, no
+dangling refs); old locations and dead code removed; full suite still matches the baseline after cleanup.
+*(Check the gate and cleanup rows in the checklist.)*

--- a/templates/sveltekit/refactor/QUICK-REFERENCE.md
+++ b/templates/sveltekit/refactor/QUICK-REFERENCE.md
@@ -1,0 +1,83 @@
+# Refactor — Quick Reference
+
+## Is it a refactor?
+
+> **Refactor = internal driver** (readability, structure, dedup, extraction, reorganization). No
+> external surface change, behavior **invariant**, nothing external retired.
+> **Migration = external driver** (package, dep version, tool, codegen, framework API) → adopt new
+> surface, retire old, behavior may change → use the `migration` template.
+> Need to scope/go-no-go a disruptive upgrade first → `upgrade-readiness`.
+
+extract/split module · rename symbol · move to canonical home · dedup helpers · restructure directory
+(service → module) · normalize conventions → all refactor.
+
+## Core invariant
+
+**Behavior byte-for-byte identical.** The tests that passed before pass after, unchanged. A refactor
+that changes behavior is two changes badly mixed — split the behavior change out.
+
+## The safety net = characterization tests
+
+You can only guarantee invariance to the extent tests pin the behavior. Thin coverage on the in-scope
+code → **add characterization tests first** (Phase 1) to create the frozen baseline.
+
+## Discover, never assume
+
+Phase 1 reads the repo for: package manager · typecheck/lint/test commands · test framework · path
+aliases/barrels. Every later phase uses these params — no hardcoded tools.
+
+## Phases
+
+| Phase | Does |
+|-------|------|
+| 1 Discover & Scope | detect params · current/target shape + kind · freeze behavior baseline → `00-overview.md` |
+| 2 Inventory & Mapping | enumerate units · pick mapping shape · assign terminal states · materialize `checklist.md` |
+| 3 Sequencing | dependency order, cycles → combined units (SKIP if independent) |
+| 4 Execute & Transform | apply transform/relocate · repoint · split imports · re-check baseline per unit |
+| 5 Verify & Cleanup | per-unit gate · global gate (suite == baseline) · remove old locations + dead code |
+
+## Refactor kinds
+
+`extract` · `rename` · `move` · `restructure` · `dedup` · `normalize`
+
+## Mapping shapes (pick one)
+
+- **Per-unit** — each unit → a rename/move/extraction target.
+- **Uniform rule** — `current form → target form` applied to N sites.
+
+## Terminal states
+
+`TRANSFORM` (reshape/rename in place + repoint) · `RELOCATE` (move/extract to new internal home +
+repoint + remove old at cleanup) · `DROP` (dead / redundant duplicate — delete) · `NO-OP` (already in
+target shape).
+
+## Checklist = the spine (multi-person coordination)
+
+One unit = one row = one line. `| # | unit | action | target | terminal | owner | depends-on | status | PR |`
+Status: `todo → claimed → in-progress → in-review → done`. Gate rows unlock only when all units `done`.
+**Merge discipline:** claim only your row · never reflow/re-sort · append your PR link.
+
+## Never mix a behavior change into a refactor
+
+Found a bug or needed semantic change mid-refactor? Split it into its own non-refactor change. Every
+refactor unit stays behavior-preserving.
+
+## Repoint safely (Phase 4)
+
+```typescript
+// split shared imports so parallel rows don't collide — one line per unit
+import { formatWidgetLabel } from '$lib/misc';     // renamed
+import { widgetHelpers } from '$lib/misc';         // untouched, other rows
+```
+
+## Global gate before cleanup
+
+```bash
+<test>   # full suite matches the frozen Phase-1 baseline
+grep -rn "<old-internal-path>" src/ --include=*.ts --include=*.svelte
+# expect nothing → then: git rm <emptied-old-file>  (+ delete dead code)
+```
+
+## Verify
+
+Run the **discovered** `<typecheck> · <lint> · <test>`; the suite must match the pre-refactor baseline.

--- a/templates/sveltekit/refactor/README.md
+++ b/templates/sveltekit/refactor/README.md
@@ -1,0 +1,112 @@
+# Refactor Template
+
+Plan and execute an **internal-driven refactor** in any SvelteKit codebase: reshape, rename, extract,
+move, or deduplicate code across every affected site, coordinate the work across one or more people via
+a shared checklist, and keep observable behavior **byte-for-byte identical** throughout.
+
+This template is **stack-agnostic**. It never assumes a package manager, test runner, or directory
+layout — every such detail is **discovered from the target repo** in Phase 1 and referenced as a
+parameter thereafter. It is the internal-driven sibling of the `migration` template and reuses the same
+discovery model and checklist convention.
+
+## What counts as a refactor (vs a migration)
+
+> **Refactor = the driver is internal.** Readability, structure, dedup, extraction, reorganization.
+> **No external surface changes** (no dependency added/removed/upgraded, no tool or framework API
+> change), behavior is **invariant**, and nothing external is retired.
+>
+> **Migration = the driver is external** (a new package, dependency version, tool, codegen pipeline, or
+> framework API); you adopt a new surface and retire the old one, and behavior may shift intentionally.
+> Use the `migration` template for that.
+
+Examples that belong here: extract/split a module, rename a symbol across the tree, move code to a
+canonical home, deduplicate helpers, restructure a directory layout (e.g. service → module
+architecture), normalize conventions. If the change is *driven by* a dependency/tool/version, it is a
+migration, not a refactor.
+
+## Core Invariant
+
+**Observable behavior is byte-for-byte identical, before and after.** The tests that passed before must
+pass after, unchanged — same inputs, same outputs, same side effects. This is the contract at the
+center, and it never bends: a refactor that changes behavior is not a refactor, it's two changes badly
+mixed. If a behavior change is genuinely needed, it is done as a **separate, non-refactor change**.
+
+**The safety net is characterization tests.** You can only guarantee invariance to the extent behavior
+is pinned by tests. Where coverage of the in-scope code is thin, **add characterization tests first**
+(Phase 1) so the refactor has a baseline to be checked against.
+
+## Principles
+
+1. **Discover, never assume.** Commands, tools, and conventions come from the target repo (Phase 1),
+   not from this template.
+2. **The unit is the smallest independently-changeable thing** — a symbol, a definition, a call-site —
+   not a whole file. One file often has several independent refactor units.
+3. **The mapping is general.** "What happens to each unit" can be *per-unit* (rename map, move map,
+   extraction boundaries) or a *uniform rule* (one normalization applied to N sites). Pick the shape
+   that fits; the template does not force one.
+4. **Never mix a behavior change into a refactor.** If you discover a bug or a needed semantic change
+   mid-refactor, split it out into its own change — keep every refactor unit behavior-preserving.
+5. **The checklist is the spine.** For any refactor touched by more than one person, `checklist.md` is
+   the single shared, committed coordination artifact. Everything else is read-only methodology.
+6. **Verify against the frozen baseline.** Behavior is confirmed unchanged by re-running the Phase-1
+   baseline; cleanup of old internal locations happens only after references to them are gone.
+
+## Phases
+
+1. **Discover & Scope** — detect repo parameters (typecheck/lint/test commands, package manager,
+   test framework, import conventions); define the current shape, the target shape, and the refactor
+   kind; establish the behavior-invariance baseline (add characterization tests where thin). Fills
+   `00-overview.md`.
+2. **Inventory & Mapping** — enumerate every in-scope unit; define the mapping (per-unit or uniform
+   rule); assign each unit a terminal state; materialize `checklist.md`.
+3. **Sequencing** — order units by dependency, leaf-first, grouping cycles; *SKIP* when units are
+   independent.
+4. **Execute & Transform** — the per-unit ritual: apply the transform/relocation, repoint consumers,
+   keep the work parallel-safe, and re-run the baseline after each unit to confirm behavior held.
+5. **Verify & Cleanup** — verify with the discovered commands against the frozen baseline, confirm no
+   references to old internal locations remain, and remove the emptied old locations and any dead code.
+
+## The Shared Checklist Convention
+
+`checklist.md` (generated into the plan) is where a team coordinates. It is the same convention the
+`migration` template uses, adapted to refactor actions. It rides *with the artifact* so co-editors see
+the rules where they work.
+
+**Row schema — one unit per row, one row per line:**
+
+```markdown
+| # | unit | action | target | terminal | owner | depends-on | status | PR |
+|---|------|--------|--------|----------|-------|-----------|--------|----|
+| 1 | formatWidget | rename | formatWidgetLabel | TRANSFORM | @a | — | todo | — |
+| 2 | widgetHelpers | move | $lib/widgets/utils | RELOCATE | @b | — | todo | — |
+```
+
+**Terminal states:** `TRANSFORM` (reshape/rename in place + repoint) · `RELOCATE` (move/extract to a
+new internal home + repoint + remove old location at cleanup) · `DROP` (dead or now-redundant duplicate
+— delete) · `NO-OP` (already in the target shape).
+
+**Status lifecycle:** `todo → claimed → in-progress → in-review → done`.
+
+**Gate rows** (unlock only when all unit rows are `done`): full suite matches the frozen baseline ·
+no references to old internal locations · cleanup.
+
+**Merge discipline (why concurrent editing stays conflict-free):** one unit = one row = one line; claim
+by editing only your row; never reflow or re-sort the table; append your PR link.
+
+> Note: the MCP loader serves only each template's own README/phases/QUICK-REFERENCE — there is no
+> cross-template include. Sharing the convention with `migration` means the same authored convention
+> text, kept consistent by hand.
+
+## When to Use
+
+- Extracting/splitting modules or restructuring a directory layout (e.g. service → module)
+- Renaming symbols, types, or modules across the codebase
+- Moving code to canonical homes; deduplicating helpers/types
+- Normalizing conventions or reshaping an internal API — with no behavior change
+
+## When NOT to Use
+
+- The change is driven by a dependency/tool/framework-version, or retires an external surface, or
+  intentionally changes behavior → use `migration`
+- A disruptive upgrade you first need to scope and get go/no-go on → use `upgrade-readiness`
+- Building something new with no existing code → use `client-module`

--- a/templates/sveltekit/refactor/meta.json
+++ b/templates/sveltekit/refactor/meta.json
@@ -1,0 +1,26 @@
+{
+  "name": "refactor",
+  "description": "Plan and execute an internal-driven refactor in any SvelteKit codebase: reshape, rename, extract, move, or deduplicate code across every affected site while keeping observable behavior byte-for-byte identical, coordinated via a shared checklist. No external dependency, tool, or API change. Stack-agnostic — the repo's tools, commands, and conventions are discovered, not assumed.",
+  "use_cases": [
+    "extracting or splitting a module; restructuring directory layout (e.g. service to module architecture)",
+    "renaming a symbol, type, or module across the codebase",
+    "moving code to a canonical internal home and repointing consumers",
+    "deduplicating repeated helpers/types into a single canonical version",
+    "reshaping an internal API or normalizing conventions without changing behavior",
+    "large-scale internal cleanup coordinated across many owners and PRs",
+    "any 'reorganize the code without changing what it does' job"
+  ],
+  "phases": [
+    { "file": "01-discover-and-scope.md", "name": "Discover & Scope" },
+    { "file": "02-inventory-and-mapping.md", "name": "Inventory & Mapping" },
+    { "file": "03-sequencing.md", "name": "Sequencing" },
+    { "file": "04-execute-and-transform.md", "name": "Execute & Transform" },
+    { "file": "05-verify-and-cleanup.md", "name": "Verify & Cleanup" }
+  ],
+  "verification": [
+    { "command": "<typecheck>", "description": "The repo's typecheck command, detected in Phase 1 (e.g. a svelte-check script) — must be clean" },
+    { "command": "<lint>", "description": "The repo's lint command, detected in Phase 1 — catches dangling imports off moved/renamed code" },
+    { "command": "<test>", "description": "The repo's test command, detected in Phase 1 — must match the pre-refactor baseline exactly (behavior is invariant)" },
+    { "command": "grep -rn \"<old-internal-path>\" src/ --include=*.ts --include=*.svelte --include=*.js", "description": "Cleanup gate: zero references to a relocated/renamed unit's old path remain before the old location is removed" }
+  ]
+}


### PR DESCRIPTION
Internal-driven, behavior-invariant refactor template for any SvelteKit codebase (sibling of migration). 
Core invariant: behavior byte-for-byte identical, pinned by characterization tests. 
Phases: discover-and-scope, inventory-and-mapping, sequencing, execute-and-transform, verify-and-cleanup. 
Reuses migration's discovery model + shared checklist convention; stack-agnostic (discovered <pm>/<typecheck>/<lint>/<test>). 
Terminal states TRANSFORM/RELOCATE/DROP/NO-OP; no external retire — internal cleanup only.